### PR TITLE
Range Query

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Parser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Parser.scala
@@ -118,14 +118,15 @@ object Parser {
   def rangeQuery(s: String) = {
     val inclLower =
       P.charIn('{', '[').map(lowerBound => lowerBound == '[') <* maybeSpace
-    val lower = P.not(P.stringIn(reserved)).with1 *> (alpha | digit | P.char('.')).rep
+    val bound =
+      P.char('*').as(None) | P.not(P.stringIn(reserved)).with1 *> (alpha | digit | P.char('.')).rep
+        .map(Some(_))
     val to = spaces *> P.string("TO") <* spaces
-    val upper = P.not(P.stringIn(reserved)).with1 *> (alpha | digit | P.char('.')).rep
     val inclUpper = maybeSpace *> P.charIn('}', ']').map(upperBound => upperBound == ']')
     val wholeThingWithSpaces =
-      (inclLower ~ lower ~ to ~ upper ~ inclUpper)
+      (inclLower ~ bound ~ to ~ bound ~ inclUpper)
         .map { case ((((lb, l), _), u), ub) =>
-          RangeQ(Some(l), Some(u), lb, ub)
+          RangeQ(l, u, lb, ub)
         }
     wholeThingWithSpaces.parse(s)
   }

--- a/core/src/main/scala/pink/cozydev/lucille/Parser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Parser.scala
@@ -117,16 +117,16 @@ object Parser {
 
   def rangeQuery(s: String) = {
     val inclLower =
-      P.charIn('{', '[').map(lowerBound => lowerBound == '[')
+      P.charIn('{', '[').map(lowerBound => lowerBound == '[') <* maybeSpace
     val lower = P.not(P.stringIn(reserved)).with1 *> (alpha | digit | P.char('.')).rep
-    val to = P.string("TO")
+    val to = spaces *> P.string("TO") <* spaces
     val upper = P.not(P.stringIn(reserved)).with1 *> (alpha | digit | P.char('.')).rep
-    val inclUpper = P.charIn('}', ']').map(upperBound => upperBound == ']')
+    val inclUpper = maybeSpace *> P.charIn('}', ']').map(upperBound => upperBound == ']')
     val wholeThingWithSpaces =
-      (inclLower ~ maybeSpace ~ lower ~ spaces ~ to ~ spaces ~ upper ~ maybeSpace ~ inclUpper).map {
-        case ((((((((lb, _), l), _), _), _), u), _), ub) =>
+      (inclLower ~ lower ~ to ~ upper ~ inclUpper)
+        .map { case ((((lb, l), _), u), ub) =>
           RangeQ(Some(l), Some(u), lb, ub)
-      }
+        }
     wholeThingWithSpaces.parse(s)
   }
 

--- a/core/src/main/scala/pink/cozydev/lucille/Parser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Parser.scala
@@ -123,12 +123,12 @@ object Parser {
         .map(Some(_))
     val to = spaces *> P.string("TO") <* spaces
     val inclUpper = maybeSpace *> P.charIn('}', ']').map(upperBound => upperBound == ']')
-    val wholeThingWithSpaces =
+    val wholeThing =
       (inclLower ~ bound ~ to ~ bound ~ inclUpper)
         .map { case ((((lb, l), _), u), ub) =>
           RangeQ(l, u, lb, ub)
         }
-    wholeThingWithSpaces.parse(s)
+    wholeThing.parse(s)
   }
 
   // Tie compound queries together recursively

--- a/core/src/main/scala/pink/cozydev/lucille/Parser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Parser.scala
@@ -115,19 +115,20 @@ object Parser {
   def unaryMinus(query: P[Query]): P[UnaryMinus] =
     P.char('-') *> query.map(UnaryMinus.apply)
 
-  def rangeQuery: P[RangeQ[_]] = {
-    val inclLower =
-      P.charIn('{', '[').map(lowerBound => lowerBound == '[') <* maybeSpace
-    val bound =
+  // Range query
+  // e.g. '{cats TO dogs}', '[1 TO *}'
+  def rangeQuery: P[RangeQ] = {
+    val inclLower = P.charIn('{', '[').map(lowerBound => lowerBound == '[') <* maybeSpace
+    val inclUpper = maybeSpace *> P.charIn('}', ']').map(upperBound => upperBound == ']')
+    val boundValue =
       P.char('*').as(None) | P.not(P.stringIn(reserved)).with1 *> (alpha | digit | P.char(
         '.'
       )).rep.string
         .map(Some(_))
     val to = spaces *> P.string("TO") <* spaces
-    val inclUpper = maybeSpace *> P.charIn('}', ']').map(upperBound => upperBound == ']')
-    (inclLower ~ bound ~ to ~ bound ~ inclUpper)
-      .map { case ((((lb, l), _), u), ub) =>
-        RangeQ(l, u, lb, ub)
+    (inclLower ~ boundValue ~ to ~ boundValue ~ inclUpper)
+      .map { case ((((il, l), _), u), iu) =>
+        RangeQ(l, u, il, iu)
       }
   }
 

--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -33,4 +33,10 @@ object Query {
   final case class Group(qs: NonEmptyList[Query]) extends Query
   final case class UnaryPlus(q: Query) extends Query
   final case class UnaryMinus(q: Query) extends Query
+  final case class RangeQ[A](
+      lower: Option[A],
+      upper: Option[A],
+      lowerInc: Boolean,
+      upperInc: Boolean,
+  ) extends Query
 }

--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -33,9 +33,9 @@ object Query {
   final case class Group(qs: NonEmptyList[Query]) extends Query
   final case class UnaryPlus(q: Query) extends Query
   final case class UnaryMinus(q: Query) extends Query
-  final case class RangeQ[A](
-      lower: Option[A],
-      upper: Option[A],
+  final case class RangeQ(
+      lower: Option[String],
+      upper: Option[String],
       lowerInc: Boolean,
       upperInc: Boolean,
   ) extends Query

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -182,19 +182,28 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     )
   }
 
-  test("name:[Jones TO Smith]".fail) {
+  test("name:[Jones TO Smith]") {
     val r = parseQ("name:[Jones TO Smith]")
-    assert(r.isRight)
+    assertEquals(
+      r,
+      Right(NonEmptyList.of(FieldQ("name", RangeQ(Some("Jones"), Some("Smith"), true, true)))),
+    )
   }
 
-  test("score:{2.5 TO 7.3}".fail) {
+  test("score:{2.5 TO 7.3}") {
     val r = parseQ("score:{2.5 TO 7.3}")
-    assert(r.isRight)
+    assertEquals(
+      r,
+      Right(NonEmptyList.of(FieldQ("score", RangeQ(Some("2.5"), Some("7.3"), false, false)))),
+    )
   }
 
-  test("score:{2.5 TO *]".fail) {
+  test("score:{2.5 TO *]") {
     val r = parseQ("score:{2.5 TO *]")
-    assert(r.isRight)
+    assertEquals(
+      r,
+      Right(NonEmptyList.of(FieldQ("score", RangeQ(Some("2.5"), None, false, true)))),
+    )
   }
 
   test("jones^2 OR smith^0.5".fail) {


### PR DESCRIPTION
- adds `RangeQ` class
- adds `rangeQuery` parser
  - parses inclusive or exclusive boundaries
  - parses wildcard boundary value (`*`)
  - parses boundary values as strings `(a-zA-Z0-9.)`

resolves #11 
<details><summary>old notes</summary>

~no where close to working yet, just parsing a single string~
pretty close to working 😎 

### Need Help With
- [x] how do I connect to the rest of the query parsing? If I pass in `query: Parser[Query]` instead of a string, how do I make that connect and work? 

### Sam's TODOs (Andrew don't look)
- [x] currently lower and upper are parsing into a non empty list of characters, want to parse into either `String` or `Float` or `Int` I guess?
  - does this make sense actually?
  - if lucene allows `{5 TO Janeway}` then maybe parsing as more than a string doesn't make sense? Need more testing I think
  - chatted with Andrew, just parse as a string for now
- [x] currently not handling a possible `*` for a bound
- [x] is a lowercase `to` allowed? currently doesn't parse
  - I think this is correct, the lucene query parser only documents `TO`, and boolean operators _must_ be all caps. Should probably test against lucene to be sure, but for now this is fine
- [x] is there a way to parse the spaces and maybe spaces, but drop all of the units out of the map? That is a WILD looking tuple yo

</details>