### PR TITLE
Allow more symbols in TermQ

### DIFF
--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -48,4 +48,9 @@ class PunctuationSuite extends munit.FunSuite {
     assertSingleQ(r, TermQ("first.last@email.com"))
   }
 
+  test("parse fieldQ with phraseQ with dash") {
+    val r = parseQ("name:\"cats-effect\"")
+    assertSingleQ(r, FieldQ("name", PhraseQ("cats-effect")))
+  }
+
 }

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.lucille
+import cats.data.NonEmptyList
+import cats.parse.Parser.Error
+import Query._
+import Parser._
+
+// Similar to the SingleSimpleQuerySuite but with a focus on queries with punctuation
+class PunctuationSuite extends munit.FunSuite {
+
+  def assertSingleQ(r: Either[Error, NonEmptyList[Query]], expected: Query)(implicit
+      loc: munit.Location
+  ) =
+    assertEquals(r, Right(NonEmptyList.one(expected)))
+
+  test("parse single term with period") {
+    val r = parseQ("typelevel.com")
+    assertSingleQ(r, TermQ("typelevel.com"))
+  }
+
+  test("parse single term with slash") {
+    val r = parseQ("typelevel.com/cats")
+    assertSingleQ(r, TermQ("typelevel.com/cats"))
+  }
+
+  test("parse single term with dash") {
+    val r = parseQ("cats-effect")
+    assertSingleQ(r, TermQ("cats-effect"))
+  }
+
+  test("parse single term with '@'") {
+    val r = parseQ("first.last@email.com")
+    assertSingleQ(r, TermQ("first.last@email.com"))
+  }
+
+}


### PR DESCRIPTION
Closes https://github.com/cozydev-pink/lucille/issues/17

Allows parsing the following as terms:
- typelevel.com
- typelevel.com/cats
- cats-effect
- first.last@email.com