### PR TITLE
Refactor Query classes

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Op.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Op.scala
@@ -34,17 +34,17 @@ object Op {
         case Nil =>
           op match {
             // no more ops to pair
-            case OR => NonEmptyList.of(Query.OrQ(acc))
-            case AND => NonEmptyList.of(Query.AndQ(acc))
+            case OR => NonEmptyList.of(Query.Or(acc))
+            case AND => NonEmptyList.of(Query.And(acc))
           }
         case (nextOp, q) :: tailOpP =>
           (op, nextOp) match {
             case (OR, OR) => go(acc.append(q), nextOp, tailOpP)
             case (AND, AND) => go(acc.append(q), nextOp, tailOpP)
             case (AND, OR) =>
-              go(NonEmptyList.of(q), nextOp, tailOpP).prepend(Query.AndQ(acc))
+              go(NonEmptyList.of(q), nextOp, tailOpP).prepend(Query.And(acc))
             case (OR, AND) =>
-              // TODO we only get away with not wrapping the `allButLast` in an OrQ
+              // TODO we only get away with not wrapping the `allButLast` in an Or
               //  because `OR` is the default query type. This should be configurable
               val allButLast = NonEmptyList(acc.head, acc.tail.dropRight(1))
               allButLast.concatNel(go(NonEmptyList.of(acc.last, q), nextOp, tailOpP))

--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -21,24 +21,24 @@ import cats.data.NonEmptyList
 sealed trait Query extends Product with Serializable
 
 object Query {
-  final case class TermQ(q: String) extends Query
-  final case class PhraseQ(q: String) extends Query
-  final case class FieldQ(field: String, q: Query) extends Query
-  final case class ProximityQ(q: String, num: Int) extends Query
-  final case class PrefixTerm(q: String) extends Query
-  final case class Regex(r: String) extends Query
-  final case class FuzzyTerm(q: String, num: Option[Int]) extends Query
-  final case class OrQ(qs: NonEmptyList[Query]) extends Query
-  final case class AndQ(qs: NonEmptyList[Query]) extends Query
-  final case class NotQ(q: Query) extends Query
-  final case class Group(qs: NonEmptyList[Query]) extends Query
-  final case class UnaryPlus(q: Query) extends Query
-  final case class UnaryMinus(q: Query) extends Query
-  final case class RangeQ(
+  final case class Term(str: String) extends Query
+  final case class Phrase(str: String) extends Query
+  final case class Prefix(str: String) extends Query
+  final case class Proximity(str: String, num: Int) extends Query
+  final case class Fuzzy(str: String, num: Option[Int]) extends Query
+  final case class TermRegex(str: String) extends Query
+  final case class TermRange(
       lower: Option[String],
       upper: Option[String],
       lowerInc: Boolean,
       upperInc: Boolean,
   ) extends Query
-  final case class MinimumMatchQ(qs: NonEmptyList[Query], num: Int) extends Query
+  final case class Or(qs: NonEmptyList[Query]) extends Query
+  final case class And(qs: NonEmptyList[Query]) extends Query
+  final case class Not(q: Query) extends Query
+  final case class Group(qs: NonEmptyList[Query]) extends Query
+  final case class UnaryPlus(q: Query) extends Query
+  final case class UnaryMinus(q: Query) extends Query
+  final case class MinimumMatch(qs: NonEmptyList[Query], num: Int) extends Query
+  final case class Field(field: String, q: Query) extends Query
 }

--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -33,10 +33,27 @@ object Query {
       lowerInc: Boolean,
       upperInc: Boolean,
   ) extends Query
+
   final case class Or(qs: NonEmptyList[Query]) extends Query
+  object Or {
+    def apply(head: Query, tail: Query*): Or =
+      Or(NonEmptyList(head, tail.toList))
+  }
+
   final case class And(qs: NonEmptyList[Query]) extends Query
+  object And {
+    def apply(head: Query, tail: Query*): And =
+      And(NonEmptyList(head, tail.toList))
+  }
+
   final case class Not(q: Query) extends Query
+
   final case class Group(qs: NonEmptyList[Query]) extends Query
+  object Group {
+    def apply(head: Query, tail: Query*): Group =
+      Group(NonEmptyList(head, tail.toList))
+  }
+
   final case class UnaryPlus(q: Query) extends Query
   final case class UnaryMinus(q: Query) extends Query
   final case class MinimumMatch(qs: NonEmptyList[Query], num: Int) extends Query

--- a/core/src/test/scala/pink/cozydev/lucille/OpSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/OpSuite.scala
@@ -25,7 +25,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((OR, Term("dog")))
     val result = associateOps(leftQs, opQs)
-    val expected = NonEmptyList.of(Term("the"), Or(NonEmptyList.of(Term("cat"), Term("dog"))))
+    val expected = NonEmptyList.of(Term("the"), Or(Term("cat"), Term("dog")))
     assertEquals(result, expected)
   }
 
@@ -33,7 +33,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((AND, Term("dog")))
     val result = associateOps(leftQs, opQs)
-    val expected = NonEmptyList.of(Term("the"), And(NonEmptyList.of(Term("cat"), Term("dog"))))
+    val expected = NonEmptyList.of(Term("the"), And(Term("cat"), Term("dog")))
     assertEquals(result, expected)
   }
 
@@ -42,7 +42,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     val opQs = List((OR, Term("dog")), (OR, Term("fish")))
     val result = associateOps(leftQs, opQs)
     val expected =
-      NonEmptyList.of(Term("the"), Or(NonEmptyList.of(Term("cat"), Term("dog"), Term("fish"))))
+      NonEmptyList.of(Term("the"), Or(Term("cat"), Term("dog"), Term("fish")))
     assertEquals(result, expected)
   }
 
@@ -53,7 +53,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     val expected =
       NonEmptyList.of(
         Term("the"),
-        And(NonEmptyList.of(Term("cat"), Term("dog"), Term("fish"))),
+        And(Term("cat"), Term("dog"), Term("fish")),
       )
     assertEquals(result, expected)
   }
@@ -68,7 +68,7 @@ class AssociateOpsSuite extends munit.FunSuite {
       NonEmptyList.of(
         Term("the"),
         Term("cat"),
-        And(NonEmptyList.of(Term("ocean"), Term("fish"))),
+        And(Term("ocean"), Term("fish")),
       )
     assertEquals(result, expected)
   }
@@ -82,8 +82,8 @@ class AssociateOpsSuite extends munit.FunSuite {
     val expected =
       NonEmptyList.of(
         Term("the"),
-        And(NonEmptyList.of(Term("cat"), Term("ocean"))),
-        Or(NonEmptyList.of(Term("fish"))),
+        And(Term("cat"), Term("ocean")),
+        Or(Term("fish")),
       )
     assertEquals(result, expected)
   }
@@ -99,7 +99,7 @@ class AssociateOpsSuite extends munit.FunSuite {
         Term("the"),
         Term("cat"),
         Term("ocean"),
-        And(NonEmptyList.of(Term("ocean2"), Term("fish"))),
+        And(Term("ocean2"), Term("fish")),
       )
     assertEquals(result, expected)
   }
@@ -113,8 +113,8 @@ class AssociateOpsSuite extends munit.FunSuite {
     val expected =
       NonEmptyList.of(
         Term("the"),
-        And(NonEmptyList.of(Term("cat"), Term("ocean"), Term("ocean2"))),
-        Or(NonEmptyList.of(Term("fish"))),
+        And(Term("cat"), Term("ocean"), Term("ocean2")),
+        Or(Term("fish")),
       )
     assertEquals(result, expected)
   }

--- a/core/src/test/scala/pink/cozydev/lucille/OpSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/OpSuite.scala
@@ -22,38 +22,38 @@ import Op._
 class AssociateOpsSuite extends munit.FunSuite {
 
   test("associates ORs") {
-    val leftQs = NonEmptyList.of(TermQ("the"), TermQ("cat"))
-    val opQs = List((OR, TermQ("dog")))
+    val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
+    val opQs = List((OR, Term("dog")))
     val result = associateOps(leftQs, opQs)
-    val expected = NonEmptyList.of(TermQ("the"), OrQ(NonEmptyList.of(TermQ("cat"), TermQ("dog"))))
+    val expected = NonEmptyList.of(Term("the"), Or(NonEmptyList.of(Term("cat"), Term("dog"))))
     assertEquals(result, expected)
   }
 
   test("associates ANDs") {
-    val leftQs = NonEmptyList.of(TermQ("the"), TermQ("cat"))
-    val opQs = List((AND, TermQ("dog")))
+    val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
+    val opQs = List((AND, Term("dog")))
     val result = associateOps(leftQs, opQs)
-    val expected = NonEmptyList.of(TermQ("the"), AndQ(NonEmptyList.of(TermQ("cat"), TermQ("dog"))))
+    val expected = NonEmptyList.of(Term("the"), And(NonEmptyList.of(Term("cat"), Term("dog"))))
     assertEquals(result, expected)
   }
 
   test("associates multiple ORs") {
-    val leftQs = NonEmptyList.of(TermQ("the"), TermQ("cat"))
-    val opQs = List((OR, TermQ("dog")), (OR, TermQ("fish")))
+    val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
+    val opQs = List((OR, Term("dog")), (OR, Term("fish")))
     val result = associateOps(leftQs, opQs)
     val expected =
-      NonEmptyList.of(TermQ("the"), OrQ(NonEmptyList.of(TermQ("cat"), TermQ("dog"), TermQ("fish"))))
+      NonEmptyList.of(Term("the"), Or(NonEmptyList.of(Term("cat"), Term("dog"), Term("fish"))))
     assertEquals(result, expected)
   }
 
   test("associates multiple ANDs") {
-    val leftQs = NonEmptyList.of(TermQ("the"), TermQ("cat"))
-    val opQs = List((AND, TermQ("dog")), (AND, TermQ("fish")))
+    val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
+    val opQs = List((AND, Term("dog")), (AND, Term("fish")))
     val result = associateOps(leftQs, opQs)
     val expected =
       NonEmptyList.of(
-        TermQ("the"),
-        AndQ(NonEmptyList.of(TermQ("cat"), TermQ("dog"), TermQ("fish"))),
+        Term("the"),
+        And(NonEmptyList.of(Term("cat"), Term("dog"), Term("fish"))),
       )
     assertEquals(result, expected)
   }
@@ -61,14 +61,14 @@ class AssociateOpsSuite extends munit.FunSuite {
   test("associates with OR and then AND") {
     // the cat OR ocean AND fish
     // default:the default:cat +default:ocean +default:fish
-    val leftQs = NonEmptyList.of(TermQ("the"), TermQ("cat"))
-    val opQs = List((OR, TermQ("ocean")), (AND, TermQ("fish")))
+    val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
+    val opQs = List((OR, Term("ocean")), (AND, Term("fish")))
     val result = associateOps(leftQs, opQs)
     val expected =
       NonEmptyList.of(
-        TermQ("the"),
-        TermQ("cat"),
-        AndQ(NonEmptyList.of(TermQ("ocean"), TermQ("fish"))),
+        Term("the"),
+        Term("cat"),
+        And(NonEmptyList.of(Term("ocean"), Term("fish"))),
       )
     assertEquals(result, expected)
   }
@@ -76,14 +76,14 @@ class AssociateOpsSuite extends munit.FunSuite {
   test("associates with AND and then OR") {
     // the cat AND ocean OR fish
     // default:the +default:cat +default:ocean default:fish
-    val leftQs = NonEmptyList.of(TermQ("the"), TermQ("cat"))
-    val opQs = List((AND, TermQ("ocean")), (OR, TermQ("fish")))
+    val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
+    val opQs = List((AND, Term("ocean")), (OR, Term("fish")))
     val result = associateOps(leftQs, opQs)
     val expected =
       NonEmptyList.of(
-        TermQ("the"),
-        AndQ(NonEmptyList.of(TermQ("cat"), TermQ("ocean"))),
-        OrQ(NonEmptyList.of(TermQ("fish"))),
+        Term("the"),
+        And(NonEmptyList.of(Term("cat"), Term("ocean"))),
+        Or(NonEmptyList.of(Term("fish"))),
       )
     assertEquals(result, expected)
   }
@@ -91,15 +91,15 @@ class AssociateOpsSuite extends munit.FunSuite {
   test("associates with two ORs and then AND") {
     // the cat OR ocean OR ocean2 AND fish
     // default:the default:cat default:ocean +default:ocean2 +default:fish
-    val leftQs = NonEmptyList.of(TermQ("the"), TermQ("cat"))
-    val opQs = List((OR, TermQ("ocean")), (OR, TermQ("ocean2")), (AND, TermQ("fish")))
+    val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
+    val opQs = List((OR, Term("ocean")), (OR, Term("ocean2")), (AND, Term("fish")))
     val result = associateOps(leftQs, opQs)
     val expected =
       NonEmptyList.of(
-        TermQ("the"),
-        TermQ("cat"),
-        TermQ("ocean"),
-        AndQ(NonEmptyList.of(TermQ("ocean2"), TermQ("fish"))),
+        Term("the"),
+        Term("cat"),
+        Term("ocean"),
+        And(NonEmptyList.of(Term("ocean2"), Term("fish"))),
       )
     assertEquals(result, expected)
   }
@@ -107,14 +107,14 @@ class AssociateOpsSuite extends munit.FunSuite {
   test("associates with two ANDs and then OR") {
     // the cat AND ocean AND ocean2 OR fish
     // default:the +default:cat +default:ocean +default:ocean2 default:fish
-    val leftQs = NonEmptyList.of(TermQ("the"), TermQ("cat"))
-    val opQs = List((AND, TermQ("ocean")), (AND, TermQ("ocean2")), (OR, TermQ("fish")))
+    val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
+    val opQs = List((AND, Term("ocean")), (AND, Term("ocean2")), (OR, Term("fish")))
     val result = associateOps(leftQs, opQs)
     val expected =
       NonEmptyList.of(
-        TermQ("the"),
-        AndQ(NonEmptyList.of(TermQ("cat"), TermQ("ocean"), TermQ("ocean2"))),
-        OrQ(NonEmptyList.of(TermQ("fish"))),
+        Term("the"),
+        And(NonEmptyList.of(Term("cat"), Term("ocean"), Term("ocean2"))),
+        Or(NonEmptyList.of(Term("fish"))),
       )
     assertEquals(result, expected)
   }

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -27,62 +27,62 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
 
   test("parse single term") {
     val r = parseQ("the")
-    assertSingleTerm(r, TermQ("the"))
+    assertSingleTerm(r, Term("the"))
   }
 
   test("parse single term with trailing whitespace") {
     val r = parseQ("the   ")
-    assertSingleTerm(r, TermQ("the"))
+    assertSingleTerm(r, Term("the"))
   }
 
   test("parse single term with leading whitespace") {
     val r = parseQ("  the")
-    assertSingleTerm(r, TermQ("the"))
+    assertSingleTerm(r, Term("the"))
   }
 
   test("parse single term with trailing and leading whitespace") {
     val r = parseQ("  the      ")
-    assertSingleTerm(r, TermQ("the"))
+    assertSingleTerm(r, Term("the"))
   }
 
   test("parse phrase term") {
     val r = parseQ("\"The cat jumped\"")
-    assertSingleTerm(r, PhraseQ("The cat jumped"))
+    assertSingleTerm(r, Phrase("The cat jumped"))
   }
 
   test("parse phrase term with leading and trailing whitespace") {
     val r = parseQ("  \"The cat jumped\"  ")
-    assertSingleTerm(r, PhraseQ("The cat jumped"))
+    assertSingleTerm(r, Phrase("The cat jumped"))
   }
 
   test("parse field query with term") {
     val r = parseQ("fieldName:cat")
-    assertSingleTerm(r, FieldQ("fieldName", TermQ("cat")))
+    assertSingleTerm(r, Field("fieldName", Term("cat")))
   }
 
   test("parse field query with term with leading and trailing whitespace") {
     val r = parseQ("  fieldName:cat  ")
-    assertSingleTerm(r, FieldQ("fieldName", TermQ("cat")))
+    assertSingleTerm(r, Field("fieldName", Term("cat")))
   }
 
   test("parse field query with phrase") {
     val r = parseQ("fieldName:\"The cat jumped\"")
-    assertEquals(r, Right(NonEmptyList.of(FieldQ("fieldName", PhraseQ("The cat jumped")))))
+    assertEquals(r, Right(NonEmptyList.of(Field("fieldName", Phrase("The cat jumped")))))
   }
 
   test("parse single term with numbers") {
     val r = parseQ("catch22")
-    assertSingleTerm(r, TermQ("catch22"))
+    assertSingleTerm(r, Term("catch22"))
   }
 
   test("parse field query with number in name") {
     val r = parseQ("fieldName42:cat")
-    assertSingleTerm(r, FieldQ("fieldName42", TermQ("cat")))
+    assertSingleTerm(r, Field("fieldName42", Term("cat")))
   }
 
   test("parse field query with number in term") {
     val r = parseQ("fieldName42:cat42")
-    assertSingleTerm(r, FieldQ("fieldName42", TermQ("cat42")))
+    assertSingleTerm(r, Field("fieldName42", Term("cat42")))
   }
 
   test("field names cannot be reserved suffix operators") {
@@ -101,25 +101,25 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 
   test("parse multiple terms completely") {
     val r = parseQ("The cat jumped")
-    assertEquals(r, Right(NonEmptyList.of(TermQ("The"), TermQ("cat"), TermQ("jumped"))))
+    assertEquals(r, Right(NonEmptyList.of(Term("The"), Term("cat"), Term("jumped"))))
   }
 
   test("parse multiple terms with lots of spaces completely") {
     val r = parseQ("The cat   jumped   ")
-    assertEquals(r, Right(NonEmptyList.of(TermQ("The"), TermQ("cat"), TermQ("jumped"))))
+    assertEquals(r, Right(NonEmptyList.of(Term("The"), Term("cat"), Term("jumped"))))
   }
 
   test("parse field query and terms completely") {
     val r = parseQ("fieldName:The cat jumped")
     assertEquals(
       r,
-      Right(NonEmptyList.of(FieldQ("fieldName", TermQ("The")), TermQ("cat"), TermQ("jumped"))),
+      Right(NonEmptyList.of(Field("fieldName", Term("The")), Term("cat"), Term("jumped"))),
     )
   }
 
   test("parse proximity query completely") {
     val r = parseQ("\"derp lerp\"~3")
-    assertEquals(r, Right(NonEmptyList.of(ProximityQ("derp lerp", 3))))
+    assertEquals(r, Right(NonEmptyList.of(Proximity("derp lerp", 3))))
   }
 
   test("parse proximity with decimal does not parse") {
@@ -129,12 +129,12 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 
   test("parse fuzzy term without number parses completely") {
     val r = parseQ("derp~")
-    assertEquals(r, Right(NonEmptyList.of(FuzzyTerm("derp", None))))
+    assertEquals(r, Right(NonEmptyList.of(Fuzzy("derp", None))))
   }
 
   test("parse fuzzy term with number parses completely") {
     val r = parseQ("derp~2")
-    assertEquals(r, Right(NonEmptyList.of(FuzzyTerm("derp", Some(2)))))
+    assertEquals(r, Right(NonEmptyList.of(Fuzzy("derp", Some(2)))))
   }
 
   test("parse fuzzy term with decimal does not parse") {
@@ -151,7 +151,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          OrQ(NonEmptyList.of(TermQ("derp"), TermQ("lerp")))
+          Or(NonEmptyList.of(Term("derp"), Term("lerp")))
         )
       ),
     )
@@ -163,7 +163,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          OrQ(NonEmptyList.of(TermQ("derp"), TermQ("lerp"), TermQ("slerp")))
+          Or(NonEmptyList.of(Term("derp"), Term("lerp"), Term("slerp")))
         )
       ),
     )
@@ -175,7 +175,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          OrQ(NonEmptyList.of(TermQ("derp"), PhraseQ("lerp slerp")))
+          Or(NonEmptyList.of(Term("derp"), Phrase("lerp slerp")))
         )
       ),
     )
@@ -217,7 +217,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(NonEmptyList.of(TermQ("derp"), TermQ("lerp")))
+          And(NonEmptyList.of(Term("derp"), Term("lerp")))
         )
       ),
     )
@@ -229,8 +229,8 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          TermQ("term"),
-          OrQ(NonEmptyList.of(TermQ("derp"), TermQ("lerp"))),
+          Term("term"),
+          Or(NonEmptyList.of(Term("derp"), Term("lerp"))),
         )
       ),
     )
@@ -242,8 +242,8 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          OrQ(NonEmptyList.of(TermQ("derp"), TermQ("lerp"))),
-          TermQ("slerp"),
+          Or(NonEmptyList.of(Term("derp"), Term("lerp"))),
+          Term("slerp"),
         )
       ),
     )
@@ -255,8 +255,8 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(NonEmptyList.of(TermQ("derp"), TermQ("lerp"))),
-          TermQ("slerp"),
+          And(NonEmptyList.of(Term("derp"), Term("lerp"))),
+          Term("slerp"),
         )
       ),
     )
@@ -268,7 +268,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(NonEmptyList.of(TermQ("derp"), PhraseQ("lerp slerp")))
+          And(NonEmptyList.of(Term("derp"), Phrase("lerp slerp")))
         )
       ),
     )
@@ -280,7 +280,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(NonEmptyList.of(TermQ("derp"), PhraseQ("lerp slerp")))
+          And(NonEmptyList.of(Term("derp"), Phrase("lerp slerp")))
         )
       ),
     )
@@ -292,10 +292,10 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(NonEmptyList.of(TermQ("derp"), TermQ("lerp"))),
-          TermQ("slerp"),
-          OrQ(NonEmptyList.of(TermQ("orA"), TermQ("orB"))),
-          TermQ("last"),
+          And(NonEmptyList.of(Term("derp"), Term("lerp"))),
+          Term("slerp"),
+          Or(NonEmptyList.of(Term("orA"), Term("orB"))),
+          Term("last"),
         )
       ),
     )
@@ -307,7 +307,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          NotQ(TermQ("derp"))
+          Not(Term("derp"))
         )
       ),
     )
@@ -319,7 +319,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(NonEmptyList.of(TermQ("derp"), NotQ(TermQ("lerp"))))
+          And(NonEmptyList.of(Term("derp"), Not(Term("lerp"))))
         )
       ),
     )
@@ -333,7 +333,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(NonEmptyList.of(TermQ("The"), TermQ("cat"), TermQ("jumped"))))
+        NonEmptyList.of(Group(NonEmptyList.of(Term("The"), Term("cat"), Term("jumped"))))
       ),
     )
   }
@@ -343,7 +343,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(NonEmptyList.of(TermQ("The"), TermQ("cat"), TermQ("jumped"))))
+        NonEmptyList.of(Group(NonEmptyList.of(Term("The"), Term("cat"), Term("jumped"))))
       ),
     )
   }
@@ -354,9 +354,9 @@ class GroupQuerySuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          TermQ("animals"),
-          NotQ(
-            Group(NonEmptyList.of(AndQ(NonEmptyList.of(TermQ("cats"), TermQ("dogs")))))
+          Term("animals"),
+          Not(
+            Group(NonEmptyList.of(And(NonEmptyList.of(Term("cats"), Term("dogs")))))
           ),
         )
       ),
@@ -369,9 +369,9 @@ class GroupQuerySuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          FieldQ(
+          Field(
             "title",
-            Group(NonEmptyList.of(AndQ(NonEmptyList.of(TermQ("cats"), TermQ("dogs"))))),
+            Group(NonEmptyList.of(And(NonEmptyList.of(Term("cats"), Term("dogs"))))),
           )
         )
       ),
@@ -384,12 +384,12 @@ class GroupQuerySuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(
+          And(
             NonEmptyList.of(
-              FieldQ("title", TermQ("test")),
+              Field("title", Term("test")),
               Group(
                 NonEmptyList.of(
-                  OrQ(NonEmptyList.of(TermQ("pass"), TermQ("fail")))
+                  Or(NonEmptyList.of(Term("pass"), Term("fail")))
                 )
               ),
             )
@@ -401,12 +401,12 @@ class GroupQuerySuite extends munit.FunSuite {
 
   test("parse nested group query with trailing term") {
     val r = parseQ("(title:test AND (pass OR fail)) extra")
-    val gq = AndQ(
+    val gq = And(
       NonEmptyList.of(
-        FieldQ("title", TermQ("test")),
+        Field("title", Term("test")),
         Group(
           NonEmptyList.of(
-            OrQ(NonEmptyList.of(TermQ("pass"), TermQ("fail")))
+            Or(NonEmptyList.of(Term("pass"), Term("fail")))
           )
         ),
       )
@@ -414,19 +414,19 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(NonEmptyList.of(gq)), TermQ("extra"))
+        NonEmptyList.of(Group(NonEmptyList.of(gq)), Term("extra"))
       ),
     )
   }
 
   test("parse nested group query AND'd with a phrase query") {
     val r = parseQ("(title:test AND (pass OR fail)) AND \"extra phrase\"")
-    val gq = AndQ(
+    val gq = And(
       NonEmptyList.of(
-        FieldQ("title", TermQ("test")),
+        Field("title", Term("test")),
         Group(
           NonEmptyList.of(
-            OrQ(NonEmptyList.of(TermQ("pass"), TermQ("fail")))
+            Or(NonEmptyList.of(Term("pass"), Term("fail")))
           )
         ),
       )
@@ -435,10 +435,10 @@ class GroupQuerySuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(
+          And(
             NonEmptyList.of(
               Group(NonEmptyList.of(gq)),
-              PhraseQ("extra phrase"),
+              Phrase("extra phrase"),
             )
           )
         )

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -151,7 +151,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          Or(NonEmptyList.of(Term("derp"), Term("lerp")))
+          Or(Term("derp"), Term("lerp"))
         )
       ),
     )
@@ -163,7 +163,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          Or(NonEmptyList.of(Term("derp"), Term("lerp"), Term("slerp")))
+          Or(Term("derp"), Term("lerp"), Term("slerp"))
         )
       ),
     )
@@ -175,7 +175,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          Or(NonEmptyList.of(Term("derp"), Phrase("lerp slerp")))
+          Or(Term("derp"), Phrase("lerp slerp"))
         )
       ),
     )
@@ -217,7 +217,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          And(NonEmptyList.of(Term("derp"), Term("lerp")))
+          And(Term("derp"), Term("lerp"))
         )
       ),
     )
@@ -230,7 +230,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       Right(
         NonEmptyList.of(
           Term("term"),
-          Or(NonEmptyList.of(Term("derp"), Term("lerp"))),
+          Or(Term("derp"), Term("lerp")),
         )
       ),
     )
@@ -242,7 +242,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          Or(NonEmptyList.of(Term("derp"), Term("lerp"))),
+          Or(Term("derp"), Term("lerp")),
           Term("slerp"),
         )
       ),
@@ -255,7 +255,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          And(NonEmptyList.of(Term("derp"), Term("lerp"))),
+          And(Term("derp"), Term("lerp")),
           Term("slerp"),
         )
       ),
@@ -268,7 +268,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          And(NonEmptyList.of(Term("derp"), Phrase("lerp slerp")))
+          And(Term("derp"), Phrase("lerp slerp"))
         )
       ),
     )
@@ -280,7 +280,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          And(NonEmptyList.of(Term("derp"), Phrase("lerp slerp")))
+          And(Term("derp"), Phrase("lerp slerp"))
         )
       ),
     )
@@ -292,9 +292,9 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          And(NonEmptyList.of(Term("derp"), Term("lerp"))),
+          And(Term("derp"), Term("lerp")),
           Term("slerp"),
-          Or(NonEmptyList.of(Term("orA"), Term("orB"))),
+          Or(Term("orA"), Term("orB")),
           Term("last"),
         )
       ),
@@ -319,7 +319,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          And(NonEmptyList.of(Term("derp"), Not(Term("lerp"))))
+          And(Term("derp"), Not(Term("lerp")))
         )
       ),
     )
@@ -333,7 +333,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(NonEmptyList.of(Term("The"), Term("cat"), Term("jumped"))))
+        NonEmptyList.of(Group(Term("The"), Term("cat"), Term("jumped")))
       ),
     )
   }
@@ -343,7 +343,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(NonEmptyList.of(Term("The"), Term("cat"), Term("jumped"))))
+        NonEmptyList.of(Group(Term("The"), Term("cat"), Term("jumped")))
       ),
     )
   }
@@ -356,7 +356,7 @@ class GroupQuerySuite extends munit.FunSuite {
         NonEmptyList.of(
           Term("animals"),
           Not(
-            Group(NonEmptyList.of(And(NonEmptyList.of(Term("cats"), Term("dogs")))))
+            Group(And(Term("cats"), Term("dogs")))
           ),
         )
       ),
@@ -371,7 +371,7 @@ class GroupQuerySuite extends munit.FunSuite {
         NonEmptyList.of(
           Field(
             "title",
-            Group(NonEmptyList.of(And(NonEmptyList.of(Term("cats"), Term("dogs"))))),
+            Group(And(Term("cats"), Term("dogs"))),
           )
         )
       ),
@@ -385,14 +385,10 @@ class GroupQuerySuite extends munit.FunSuite {
       Right(
         NonEmptyList.of(
           And(
-            NonEmptyList.of(
-              Field("title", Term("test")),
-              Group(
-                NonEmptyList.of(
-                  Or(NonEmptyList.of(Term("pass"), Term("fail")))
-                )
-              ),
-            )
+            Field("title", Term("test")),
+            Group(
+              Or(Term("pass"), Term("fail"))
+            ),
           )
         )
       ),
@@ -405,16 +401,14 @@ class GroupQuerySuite extends munit.FunSuite {
       NonEmptyList.of(
         Field("title", Term("test")),
         Group(
-          NonEmptyList.of(
-            Or(NonEmptyList.of(Term("pass"), Term("fail")))
-          )
+          Or(Term("pass"), Term("fail"))
         ),
       )
     )
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(NonEmptyList.of(gq)), Term("extra"))
+        NonEmptyList.of(Group(gq), Term("extra"))
       ),
     )
   }
@@ -425,9 +419,7 @@ class GroupQuerySuite extends munit.FunSuite {
       NonEmptyList.of(
         Field("title", Term("test")),
         Group(
-          NonEmptyList.of(
-            Or(NonEmptyList.of(Term("pass"), Term("fail")))
-          )
+          Or(Term("pass"), Term("fail"))
         ),
       )
     )
@@ -436,10 +428,8 @@ class GroupQuerySuite extends munit.FunSuite {
       Right(
         NonEmptyList.of(
           And(
-            NonEmptyList.of(
-              Group(NonEmptyList.of(gq)),
-              Phrase("extra phrase"),
-            )
+            Group(gq),
+            Phrase("extra phrase"),
           )
         )
       ),

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -30,27 +30,27 @@ class PunctuationSuite extends munit.FunSuite {
 
   test("parse single term with period") {
     val r = parseQ("typelevel.com")
-    assertSingleQ(r, TermQ("typelevel.com"))
+    assertSingleQ(r, Term("typelevel.com"))
   }
 
   test("parse single term with slash") {
     val r = parseQ("typelevel.com/cats")
-    assertSingleQ(r, TermQ("typelevel.com/cats"))
+    assertSingleQ(r, Term("typelevel.com/cats"))
   }
 
   test("parse single term with dash") {
     val r = parseQ("cats-effect")
-    assertSingleQ(r, TermQ("cats-effect"))
+    assertSingleQ(r, Term("cats-effect"))
   }
 
   test("parse single term with '@'") {
     val r = parseQ("first.last@email.com")
-    assertSingleQ(r, TermQ("first.last@email.com"))
+    assertSingleQ(r, Term("first.last@email.com"))
   }
 
   test("parse fieldQ with phraseQ with dash") {
     val r = parseQ("name:\"cats-effect\"")
-    assertSingleQ(r, FieldQ("name", PhraseQ("cats-effect")))
+    assertSingleQ(r, Field("name", Phrase("cats-effect")))
   }
 
 }

--- a/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
@@ -29,7 +29,7 @@ class RegexSuite extends munit.FunSuite {
 
   test("parse single regex with wildcard star") {
     val r = parseQ("/jump.*/")
-    assertSingleQ(r, Regex("jump.*"))
+    assertSingleQ(r, TermRegex("jump.*"))
   }
 
   test("does not parse without ending slash") {
@@ -39,17 +39,17 @@ class RegexSuite extends munit.FunSuite {
 
   test("parse regex with repeat min-max") {
     val r = parseQ("/hi{1,5}/")
-    assertSingleQ(r, Regex("hi{1,5}"))
+    assertSingleQ(r, TermRegex("hi{1,5}"))
   }
 
   test("parse multipe regex in a group") {
     val r = parseQ("(/jump.*/ /.ouse/)")
-    assertSingleQ(r, Group(NonEmptyList.of(Regex("jump.*"), Regex(".ouse"))))
+    assertSingleQ(r, Group(NonEmptyList.of(TermRegex("jump.*"), TermRegex(".ouse"))))
   }
 
   test("parse regex with escaped slash") {
     val r = parseQ("""/home\/.*/""")
-    assertSingleQ(r, Regex("""home\/.*"""))
+    assertSingleQ(r, TermRegex("""home\/.*"""))
   }
 
 }

--- a/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
@@ -44,7 +44,7 @@ class RegexSuite extends munit.FunSuite {
 
   test("parse multipe regex in a group") {
     val r = parseQ("(/jump.*/ /.ouse/)")
-    assertSingleQ(r, Group(NonEmptyList.of(TermRegex("jump.*"), TermRegex(".ouse"))))
+    assertSingleQ(r, Group(TermRegex("jump.*"), TermRegex(".ouse")))
   }
 
   test("parse regex with escaped slash") {

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -99,7 +99,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          Field("title", Group(NonEmptyList.of(Or(NonEmptyList.of(Term("die"), Term("hard"))))))
+          Field("title", Group(Or(Term("die"), Term("hard"))))
         )
       ),
     )
@@ -110,7 +110,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(And(NonEmptyList.of(Term("test"), Term("results"))))
+        NonEmptyList.of(And(Term("test"), Term("results")))
       ),
     )
   }
@@ -122,10 +122,8 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       Right(
         NonEmptyList.of(
           And(
-            NonEmptyList.of(
-              Field("title", Term("test")),
-              Not(Field("title", Term("complete"))),
-            )
+            Field("title", Term("test")),
+            Not(Field("title", Term("complete"))),
           )
         )
       ),
@@ -139,19 +137,13 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       Right(
         NonEmptyList.of(
           And(
-            NonEmptyList.of(
-              Field("title", Term("test")),
-              Group(
-                NonEmptyList.of(
-                  Or(
-                    NonEmptyList.of(
-                      Prefix("pass"),
-                      Prefix("fail"),
-                    )
-                  )
-                )
-              ),
-            )
+            Field("title", Term("test")),
+            Group(
+              Or(
+                Prefix("pass"),
+                Prefix("fail"),
+              )
+            ),
           )
         )
       ),
@@ -164,7 +156,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          Field("title", Group(NonEmptyList.of(Term("pass"), Term("fail"), Term("skip"))))
+          Field("title", Group(Term("pass"), Term("fail"), Term("skip")))
         )
       ),
     )
@@ -179,7 +171,8 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
           Field(
             "title",
             Group(
-              NonEmptyList.of(UnaryPlus(Term("test")), UnaryPlus(Phrase("result unknown")))
+              UnaryPlus(Term("test")),
+              UnaryPlus(Phrase("result unknown")),
             ),
           )
         )
@@ -247,9 +240,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
           MinimumMatch(
             NonEmptyList.of(
               Group(
-                NonEmptyList.of(
-                  Or(NonEmptyList.of(Term("yellow"), Term("blue")))
-                )
+                Or(Term("yellow"), Term("blue"))
               ),
               Term("crab"),
               Term("fish"),

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -28,7 +28,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(TermQ("test"))
+        NonEmptyList.of(Term("test"))
       ),
     )
   }
@@ -38,7 +38,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(TermQ("test"), TermQ("equipment"))
+        NonEmptyList.of(Term("test"), Term("equipment"))
       ),
     )
   }
@@ -48,7 +48,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(ProximityQ("test failure", 4))
+        NonEmptyList.of(Proximity("test failure", 4))
       ),
     )
   }
@@ -58,7 +58,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(PrefixTerm("tes"))
+        NonEmptyList.of(Prefix("tes"))
       ),
     )
   }
@@ -68,7 +68,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Regex(".est(s|ing)"))
+        NonEmptyList.of(TermRegex(".est(s|ing)"))
       ),
     )
   }
@@ -78,7 +78,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(FuzzyTerm("nest", Some(4)))
+        NonEmptyList.of(Fuzzy("nest", Some(4)))
       ),
     )
   }
@@ -88,7 +88,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(FieldQ("title", TermQ("test")))
+        NonEmptyList.of(Field("title", Term("test")))
       ),
     )
   }
@@ -99,7 +99,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          FieldQ("title", Group(NonEmptyList.of(OrQ(NonEmptyList.of(TermQ("die"), TermQ("hard"))))))
+          Field("title", Group(NonEmptyList.of(Or(NonEmptyList.of(Term("die"), Term("hard"))))))
         )
       ),
     )
@@ -110,7 +110,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(AndQ(NonEmptyList.of(TermQ("test"), TermQ("results"))))
+        NonEmptyList.of(And(NonEmptyList.of(Term("test"), Term("results"))))
       ),
     )
   }
@@ -121,10 +121,10 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(
+          And(
             NonEmptyList.of(
-              FieldQ("title", TermQ("test")),
-              NotQ(FieldQ("title", TermQ("complete"))),
+              Field("title", Term("test")),
+              Not(Field("title", Term("complete"))),
             )
           )
         )
@@ -138,15 +138,15 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          AndQ(
+          And(
             NonEmptyList.of(
-              FieldQ("title", TermQ("test")),
+              Field("title", Term("test")),
               Group(
                 NonEmptyList.of(
-                  OrQ(
+                  Or(
                     NonEmptyList.of(
-                      PrefixTerm("pass"),
-                      PrefixTerm("fail"),
+                      Prefix("pass"),
+                      Prefix("fail"),
                     )
                   )
                 )
@@ -164,7 +164,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          FieldQ("title", Group(NonEmptyList.of(TermQ("pass"), TermQ("fail"), TermQ("skip"))))
+          Field("title", Group(NonEmptyList.of(Term("pass"), Term("fail"), Term("skip"))))
         )
       ),
     )
@@ -176,10 +176,10 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          FieldQ(
+          Field(
             "title",
             Group(
-              NonEmptyList.of(UnaryPlus(TermQ("test")), UnaryPlus(PhraseQ("result unknown")))
+              NonEmptyList.of(UnaryPlus(Term("test")), UnaryPlus(Phrase("result unknown")))
             ),
           )
         )
@@ -191,7 +191,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("name:[Jones TO Smith]")
     assertEquals(
       r,
-      Right(NonEmptyList.of(FieldQ("name", RangeQ(Some("Jones"), Some("Smith"), true, true)))),
+      Right(NonEmptyList.of(Field("name", TermRange(Some("Jones"), Some("Smith"), true, true)))),
     )
   }
 
@@ -199,7 +199,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("score:{2.5 TO 7.3}")
     assertEquals(
       r,
-      Right(NonEmptyList.of(FieldQ("score", RangeQ(Some("2.5"), Some("7.3"), false, false)))),
+      Right(NonEmptyList.of(Field("score", TermRange(Some("2.5"), Some("7.3"), false, false)))),
     )
   }
 
@@ -207,7 +207,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("score:{2.5 TO *]")
     assertEquals(
       r,
-      Right(NonEmptyList.of(FieldQ("score", RangeQ(Some("2.5"), None, false, true)))),
+      Right(NonEmptyList.of(Field("score", TermRange(Some("2.5"), None, false, true)))),
     )
   }
 
@@ -232,7 +232,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          MinimumMatchQ(NonEmptyList.of(TermQ("blue"), TermQ("crab"), TermQ("fish")), 2)
+          MinimumMatch(NonEmptyList.of(Term("blue"), Term("crab"), Term("fish")), 2)
         )
       ),
     )
@@ -244,15 +244,15 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         NonEmptyList.of(
-          MinimumMatchQ(
+          MinimumMatch(
             NonEmptyList.of(
               Group(
                 NonEmptyList.of(
-                  OrQ(NonEmptyList.of(TermQ("yellow"), TermQ("blue")))
+                  Or(NonEmptyList.of(Term("yellow"), Term("blue")))
                 )
               ),
-              TermQ("crab"),
-              TermQ("fish"),
+              Term("crab"),
+              Term("fish"),
             ),
             2,
           )


### PR DESCRIPTION
Renames the Query classes to ditch the `Q` suffix where possible.
When a class name would conflict with a Scala standard library class, like `Range` or `Regex` we use the prefix `Term` resulting in `TermRange` and `TermRegex`.
This also helps to indicate that these are term matching queries, as opposed to a boolean combination of queries or a field query.

Additionally we add apply methods to `And`, `Or`, and `Group`, that use varargs for conveniently constructing queries.
Closes https://github.com/cozydev-pink/lucille/issues/12