### PR TITLE
Multiquery

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Parser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Parser.scala
@@ -183,5 +183,6 @@ object Parser {
   val fullQuery = nonGrouped(recursiveQ)
 
   // TODO we need to deal with the trailing whitespace now that we support groups
-  def parseQ(s: String) = fullQuery.parseAll(s.stripTrailing)
+  def parseQ(s: String): Either[cats.parse.Parser.Error, MultiQuery] =
+    fullQuery.parseAll(s.stripTrailing).map(MultiQuery.apply)
 }

--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -20,6 +20,19 @@ import cats.data.NonEmptyList
 
 sealed trait Query extends Product with Serializable
 
+final case class MultiQuery(qs: NonEmptyList[Query]) extends Query {
+  def mapLast(f: Query => Query): MultiQuery =
+    if (qs.size == 1) MultiQuery(NonEmptyList.one(f(qs.head)))
+    else {
+      val newT = qs.tail.init :+ f(qs.last)
+      MultiQuery(NonEmptyList(qs.head, newT))
+    }
+}
+object MultiQuery {
+  def apply(head: Query, tail: Query*): MultiQuery =
+    MultiQuery(NonEmptyList(head, tail.toList))
+}
+
 object Query {
   final case class Term(str: String) extends Query
   final case class Phrase(str: String) extends Query

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -25,7 +25,7 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
   def assertSingleTerm(r: Either[Error, MultiQuery], expected: Query)(implicit
       loc: munit.Location
   ) =
-    assertEquals(r, Right(MultiQuery(NonEmptyList.one(expected))))
+    assertEquals(r, Right(MultiQuery(expected)))
 
   test("parse single term") {
     val r = parseQ("the")

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -22,8 +22,10 @@ import Parser._
 
 class SingleSimpleQuerySuite extends munit.FunSuite {
 
-  def assertSingleTerm(r: Either[Error, NonEmptyList[Query]], expected: Query) =
-    assertEquals(r, Right(NonEmptyList.of(expected)))
+  def assertSingleTerm(r: Either[Error, MultiQuery], expected: Query)(implicit
+      loc: munit.Location
+  ) =
+    assertEquals(r, Right(MultiQuery(NonEmptyList.one(expected))))
 
   test("parse single term") {
     val r = parseQ("the")
@@ -67,7 +69,7 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
 
   test("parse field query with phrase") {
     val r = parseQ("fieldName:\"The cat jumped\"")
-    assertEquals(r, Right(NonEmptyList.of(Field("fieldName", Phrase("The cat jumped")))))
+    assertEquals(r, Right(MultiQuery(Field("fieldName", Phrase("The cat jumped")))))
   }
 
   test("parse single term with numbers") {
@@ -101,25 +103,25 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 
   test("parse multiple terms completely") {
     val r = parseQ("The cat jumped")
-    assertEquals(r, Right(NonEmptyList.of(Term("The"), Term("cat"), Term("jumped"))))
+    assertEquals(r, Right(MultiQuery(Term("The"), Term("cat"), Term("jumped"))))
   }
 
   test("parse multiple terms with lots of spaces completely") {
     val r = parseQ("The cat   jumped   ")
-    assertEquals(r, Right(NonEmptyList.of(Term("The"), Term("cat"), Term("jumped"))))
+    assertEquals(r, Right(MultiQuery(Term("The"), Term("cat"), Term("jumped"))))
   }
 
   test("parse field query and terms completely") {
     val r = parseQ("fieldName:The cat jumped")
     assertEquals(
       r,
-      Right(NonEmptyList.of(Field("fieldName", Term("The")), Term("cat"), Term("jumped"))),
+      Right(MultiQuery(Field("fieldName", Term("The")), Term("cat"), Term("jumped"))),
     )
   }
 
   test("parse proximity query completely") {
     val r = parseQ("\"derp lerp\"~3")
-    assertEquals(r, Right(NonEmptyList.of(Proximity("derp lerp", 3))))
+    assertEquals(r, Right(MultiQuery(Proximity("derp lerp", 3))))
   }
 
   test("parse proximity with decimal does not parse") {
@@ -129,12 +131,12 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 
   test("parse fuzzy term without number parses completely") {
     val r = parseQ("derp~")
-    assertEquals(r, Right(NonEmptyList.of(Fuzzy("derp", None))))
+    assertEquals(r, Right(MultiQuery(Fuzzy("derp", None))))
   }
 
   test("parse fuzzy term with number parses completely") {
     val r = parseQ("derp~2")
-    assertEquals(r, Right(NonEmptyList.of(Fuzzy("derp", Some(2)))))
+    assertEquals(r, Right(MultiQuery(Fuzzy("derp", Some(2)))))
   }
 
   test("parse fuzzy term with decimal does not parse") {
@@ -150,7 +152,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Or(Term("derp"), Term("lerp"))
         )
       ),
@@ -162,7 +164,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Or(Term("derp"), Term("lerp"), Term("slerp"))
         )
       ),
@@ -174,7 +176,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Or(Term("derp"), Phrase("lerp slerp"))
         )
       ),
@@ -216,7 +218,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(Term("derp"), Term("lerp"))
         )
       ),
@@ -228,7 +230,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Term("term"),
           Or(Term("derp"), Term("lerp")),
         )
@@ -241,7 +243,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Or(Term("derp"), Term("lerp")),
           Term("slerp"),
         )
@@ -254,7 +256,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(Term("derp"), Term("lerp")),
           Term("slerp"),
         )
@@ -267,7 +269,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(Term("derp"), Phrase("lerp slerp"))
         )
       ),
@@ -279,7 +281,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(Term("derp"), Phrase("lerp slerp"))
         )
       ),
@@ -291,7 +293,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(Term("derp"), Term("lerp")),
           Term("slerp"),
           Or(Term("orA"), Term("orB")),
@@ -306,7 +308,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Not(Term("derp"))
         )
       ),
@@ -318,7 +320,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(Term("derp"), Not(Term("lerp")))
         )
       ),
@@ -333,7 +335,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(Term("The"), Term("cat"), Term("jumped")))
+        MultiQuery(Group(Term("The"), Term("cat"), Term("jumped")))
       ),
     )
   }
@@ -343,7 +345,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(Term("The"), Term("cat"), Term("jumped")))
+        MultiQuery(Group(Term("The"), Term("cat"), Term("jumped")))
       ),
     )
   }
@@ -353,7 +355,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Term("animals"),
           Not(
             Group(And(Term("cats"), Term("dogs")))
@@ -368,7 +370,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Field(
             "title",
             Group(And(Term("cats"), Term("dogs"))),
@@ -383,7 +385,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(
             Field("title", Term("test")),
             Group(
@@ -408,7 +410,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Group(gq), Term("extra"))
+        MultiQuery(Group(gq), Term("extra"))
       ),
     )
   }
@@ -426,7 +428,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(
             Group(gq),
             Phrase("extra phrase"),

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -23,10 +23,10 @@ import Parser._
 // Similar to the SingleSimpleQuerySuite but with a focus on queries with punctuation
 class PunctuationSuite extends munit.FunSuite {
 
-  def assertSingleQ(r: Either[Error, NonEmptyList[Query]], expected: Query)(implicit
+  def assertSingleQ(r: Either[Error, MultiQuery], expected: Query)(implicit
       loc: munit.Location
   ) =
-    assertEquals(r, Right(NonEmptyList.one(expected)))
+    assertEquals(r, Right(MultiQuery(NonEmptyList.one(expected))))
 
   test("parse single term with period") {
     val r = parseQ("typelevel.com")

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -15,7 +15,6 @@
  */
 
 package pink.cozydev.lucille
-import cats.data.NonEmptyList
 import cats.parse.Parser.Error
 import Query._
 import Parser._
@@ -26,7 +25,7 @@ class PunctuationSuite extends munit.FunSuite {
   def assertSingleQ(r: Either[Error, MultiQuery], expected: Query)(implicit
       loc: munit.Location
   ) =
-    assertEquals(r, Right(MultiQuery(NonEmptyList.one(expected))))
+    assertEquals(r, Right(MultiQuery(expected)))
 
   test("parse single term with period") {
     val r = parseQ("typelevel.com")

--- a/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
@@ -22,10 +22,10 @@ import Parser._
 
 class RegexSuite extends munit.FunSuite {
 
-  def assertSingleQ(r: Either[Error, NonEmptyList[Query]], expected: Query)(implicit
+  def assertSingleQ(r: Either[Error, MultiQuery], expected: Query)(implicit
       loc: munit.Location
   ) =
-    assertEquals(r, Right(NonEmptyList.one(expected)))
+    assertEquals(r, Right(MultiQuery(NonEmptyList.one(expected))))
 
   test("parse single regex with wildcard star") {
     val r = parseQ("/jump.*/")

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -28,7 +28,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Term("test"))
+        MultiQuery(Term("test"))
       ),
     )
   }
@@ -38,7 +38,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Term("test"), Term("equipment"))
+        MultiQuery(Term("test"), Term("equipment"))
       ),
     )
   }
@@ -48,7 +48,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Proximity("test failure", 4))
+        MultiQuery(Proximity("test failure", 4))
       ),
     )
   }
@@ -58,7 +58,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Prefix("tes"))
+        MultiQuery(Prefix("tes"))
       ),
     )
   }
@@ -68,7 +68,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(TermRegex(".est(s|ing)"))
+        MultiQuery(TermRegex(".est(s|ing)"))
       ),
     )
   }
@@ -78,7 +78,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Fuzzy("nest", Some(4)))
+        MultiQuery(Fuzzy("nest", Some(4)))
       ),
     )
   }
@@ -88,7 +88,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(Field("title", Term("test")))
+        MultiQuery(Field("title", Term("test")))
       ),
     )
   }
@@ -98,7 +98,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Field("title", Group(Or(Term("die"), Term("hard"))))
         )
       ),
@@ -110,7 +110,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(And(Term("test"), Term("results")))
+        MultiQuery(And(Term("test"), Term("results")))
       ),
     )
   }
@@ -120,7 +120,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(
             Field("title", Term("test")),
             Not(Field("title", Term("complete"))),
@@ -135,7 +135,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           And(
             Field("title", Term("test")),
             Group(
@@ -155,7 +155,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Field("title", Group(Term("pass"), Term("fail"), Term("skip")))
         )
       ),
@@ -167,7 +167,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           Field(
             "title",
             Group(
@@ -184,7 +184,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("name:[Jones TO Smith]")
     assertEquals(
       r,
-      Right(NonEmptyList.of(Field("name", TermRange(Some("Jones"), Some("Smith"), true, true)))),
+      Right(MultiQuery(Field("name", TermRange(Some("Jones"), Some("Smith"), true, true)))),
     )
   }
 
@@ -192,7 +192,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("score:{2.5 TO 7.3}")
     assertEquals(
       r,
-      Right(NonEmptyList.of(Field("score", TermRange(Some("2.5"), Some("7.3"), false, false)))),
+      Right(MultiQuery(Field("score", TermRange(Some("2.5"), Some("7.3"), false, false)))),
     )
   }
 
@@ -200,7 +200,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("score:{2.5 TO *]")
     assertEquals(
       r,
-      Right(NonEmptyList.of(Field("score", TermRange(Some("2.5"), None, false, true)))),
+      Right(MultiQuery(Field("score", TermRange(Some("2.5"), None, false, true)))),
     )
   }
 
@@ -224,7 +224,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           MinimumMatch(NonEmptyList.of(Term("blue"), Term("crab"), Term("fish")), 2)
         )
       ),
@@ -236,7 +236,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        NonEmptyList.of(
+        MultiQuery(
           MinimumMatch(
             NonEmptyList.of(
               Group(


### PR DESCRIPTION
Adds a `MultiQuery` class that wraps a `NonEmptyList[Query]`.

It's main purpose is to change the parser return type from `Either[Error, NonEmptyList[Query]]` to `Either[Error, MultiQuery]` and thus be one less `NonEmptyList` end users have to deal with. Additionally it serves a great place to hold the `mapLast` method.

Closes https://github.com/cozydev-pink/lucille/issues/24