### PR TITLE
Add `mapLastTerm`

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -19,6 +19,12 @@ package pink.cozydev.lucille
 import cats.data.NonEmptyList
 
 sealed trait Query extends Product with Serializable {
+
+  /** Builds a new query by applying a `TermQuery => Query` function to the last TermQuery.
+    *
+    * @param f the function to apply to the last TermQuery
+    * @return
+    */
   def mapLastTerm(f: TermQuery => Query): Query
 }
 

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -38,9 +38,27 @@ class QuerySuite extends munit.FunSuite {
     assertEquals(mq.mapLast(expandQ), mq)
   }
 
-  test("MultiQuery.mapLastTerm maps last Term in last Query") {
+  test("MultiQuery.mapLastTerm maps last Term in last Query (OR)") {
     val mq = MultiQuery(Or(Term("cats"), Term("dogs")))
     val expected = MultiQuery(Or(Term("cats"), Or(Term("dogs"), Prefix("dogs"))))
+    assertEquals(mq.mapLastTerm(expandQ), expected)
+  }
+
+  test("MultiQuery.mapLastTerm maps last Term in last Query (AND)") {
+    val mq = MultiQuery(And(Term("cats"), Term("dogs")))
+    val expected = MultiQuery(And(Term("cats"), Or(Term("dogs"), Prefix("dogs"))))
+    assertEquals(mq.mapLastTerm(expandQ), expected)
+  }
+
+  test("MultiQuery.mapLastTerm maps last Term in last Query (NOT)") {
+    val mq = MultiQuery(Term("cats"), Not(Term("dogs")))
+    val expected = MultiQuery(Term("cats"), Not(Or(Term("dogs"), Prefix("dogs"))))
+    assertEquals(mq.mapLastTerm(expandQ), expected)
+  }
+
+  test("MultiQuery.mapLastTerm maps last Term in last Query (OR + NOT)".fail) {
+    val mq = MultiQuery(Or(Term("cats"), Not(Term("dogs"))))
+    val expected = MultiQuery(Or(Term("cats"), Not(Or(Term("dogs"), Prefix("dogs")))))
     assertEquals(mq.mapLastTerm(expandQ), expected)
   }
 }

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.lucille
+
+import pink.cozydev.lucille.Query._
+
+class QuerySuite extends munit.FunSuite {
+  def expandQ(q: Query): Query =
+    q match {
+      case Query.Term(t) => Query.Or(Query.Term(t), Query.Prefix(t))
+      case _ => q
+    }
+
+  test("MultiQuery.mapLast maps last Query") {
+    val mq = MultiQuery(Term("cats"), Term("dogs"))
+    val expected = MultiQuery(Term("cats"), Or(Term("dogs"), Prefix("dogs")))
+    assertEquals(mq.mapLast(expandQ), expected)
+  }
+
+  test(
+    "MultiQuery.mapLast does not apply `f` to Term queries within boolean queries in last position"
+  ) {
+    val mq = MultiQuery(Or(Term("cats"), Term("dogs")))
+    assertEquals(mq.mapLast(expandQ), mq)
+  }
+
+  test("MultiQuery.mapLastTerm maps last Term in last Query") {
+    val mq = MultiQuery(Or(Term("cats"), Term("dogs")))
+    val expected = MultiQuery(Or(Term("cats"), Or(Term("dogs"), Prefix("dogs"))))
+    assertEquals(mq.mapLastTerm(expandQ), expected)
+  }
+}

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -25,19 +25,6 @@ class QuerySuite extends munit.FunSuite {
       case _ => q
     }
 
-  test("MultiQuery.mapLast maps last Query") {
-    val mq = MultiQuery(Term("cats"), Term("dogs"))
-    val expected = MultiQuery(Term("cats"), Or(Term("dogs"), Prefix("dogs")))
-    assertEquals(mq.mapLast(expandQ), expected)
-  }
-
-  test(
-    "MultiQuery.mapLast does not apply `f` to Term queries within boolean queries in last position"
-  ) {
-    val mq = MultiQuery(Or(Term("cats"), Term("dogs")))
-    assertEquals(mq.mapLast(expandQ), mq)
-  }
-
   test("MultiQuery.mapLastTerm maps last Term in last Query (OR)") {
     val mq = MultiQuery(Or(Term("cats"), Term("dogs")))
     val expected = MultiQuery(Or(Term("cats"), Or(Term("dogs"), Prefix("dogs"))))

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -56,7 +56,7 @@ class QuerySuite extends munit.FunSuite {
     assertEquals(mq.mapLastTerm(expandQ), expected)
   }
 
-  test("MultiQuery.mapLastTerm maps last Term in last Query (OR + NOT)".fail) {
+  test("MultiQuery.mapLastTerm maps last Term in last Query (OR + NOT)") {
     val mq = MultiQuery(Or(Term("cats"), Not(Term("dogs"))))
     val expected = MultiQuery(Or(Term("cats"), Not(Or(Term("dogs"), Prefix("dogs")))))
     assertEquals(mq.mapLastTerm(expandQ), expected)

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,8 +51,9 @@ expanded term + prefix:
 Parser.parseQ("cats do").map(mq => mq.mapLast(expandQ))
 ```
 
-Unfortunately this doesn't currently work with the final term in a boolean query:
+However, this might not work as expected when the last term is part of a boolean or field query.
+For such use cases there is also `mapLastTerm` which will pass the function `f` down through boolean and field queries if they are in the last position.
 
 ```scala mdoc
-Parser.parseQ("cats OR do").map(mq => mq.mapLast(expandQ))
+Parser.parseQ("cats OR do").map(mq => mq.mapLastTerm(expandQ))
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,16 +44,15 @@ def expandQ(q: Query): Query =
   }
 ```
 
-We can now use `expandQ` along with `mapLast` to rewrite the last term of a `MultiQuery` into our
+We can now use `expandQ` along with `mapLastTerm` to rewrite the last term of a `MultiQuery` into our
 expanded term + prefix:
 
 ```scala mdoc
-Parser.parseQ("cats do").map(mq => mq.mapLast(expandQ))
+Parser.parseQ("cats meo").map(mq => mq.mapLastTerm(expandQ))
 ```
 
-However, this might not work as expected when the last term is part of a boolean or field query.
-For such use cases there is also `mapLastTerm` which will pass the function `f` down through boolean and field queries if they are in the last position.
+This also works when the last term is part of a boolean or field query.
 
 ```scala mdoc
-Parser.parseQ("cats OR do").map(mq => mq.mapLastTerm(expandQ))
+Parser.parseQ("cats AND do").map(mq => mq.mapLastTerm(expandQ))
 ```


### PR DESCRIPTION
Replaces `mapLast` with `mapLastTerm`
Introduces a new `TermQuery` hierarchy for easily matching on "leaf node" queries.

Closes https://github.com/cozydev-pink/lucille/issues/30