### PR TITLE
Parse without`stripTrailing`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ ThisBuild / tlCiReleaseBranches := Seq("main")
 
 // use JDK 11
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("11"))
-ThisBuild / tlJdkRelease := Some(11)
+ThisBuild / tlJdkRelease := Some(8)
 
 val Scala212 = "2.12.17"
 val Scala213 = "2.13.10"

--- a/core/src/main/scala/pink/cozydev/lucille/Parser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Parser.scala
@@ -40,8 +40,7 @@ object Parser {
 
   // Term query
   // e.g. 'cat', 'catch22'
-  val term: P[String] =
-    P.not(P.stringIn(reserved).withContext("reserved")).with1 *> allowed.rep.string
+  val term: P[String] = P.not(P.stringIn(reserved)).with1 *> allowed.rep.string
   val termQ: P[Term] = term.map(Term.apply)
 
   // Phrase query
@@ -154,7 +153,7 @@ object Parser {
       .map { case ((((il, l), _), u), iu) =>
         TermRange(l, u, il, iu)
       }
-  }.withContext("range query")
+  }
 
   // Tie compound queries together recursively
   // Order is very important here

--- a/core/src/main/scala/pink/cozydev/lucille/Parser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Parser.scala
@@ -179,15 +179,8 @@ object Parser {
   )
 
   // One or more queries implicitly grouped together in a list
-  val fullQuery = nonGrouped(recursiveQ)
+  val fullQuery = nonGrouped(recursiveQ) <* maybeSpace
 
-  val whitespace: P[Unit] = P.charIn(Set(' ', '\t', '\n', '\f', '\r')).rep.void
   def parseQ(s: String): Either[cats.parse.Parser.Error, MultiQuery] =
-    fullQuery
-      .parse(s)
-      .flatMap { case (r, q) =>
-        if (r.isEmpty()) Right(MultiQuery(q))
-        else
-          whitespace.withContext("remainder").parseAll(r).as(MultiQuery(q))
-      }
+    fullQuery.parseAll(s).map(MultiQuery.apply)
 }


### PR DESCRIPTION
Parsing without manually stripping off all the whitespace at the end of the string.
Also, sets our release back to JDK8

closes https://github.com/cozydev-pink/lucille/issues/33