### PR TITLE
Tweak `mapLastTerm`

### DIFF
--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -17,6 +17,7 @@
 package pink.cozydev.lucille
 
 import pink.cozydev.lucille.Query._
+import pink.cozydev.lucille.Parser
 
 class QuerySuite extends munit.FunSuite {
   def expandQ(q: Query): Query =
@@ -47,5 +48,23 @@ class QuerySuite extends munit.FunSuite {
     val mq = MultiQuery(Or(Term("cats"), Not(Term("dogs"))))
     val expected = MultiQuery(Or(Term("cats"), Not(Or(Term("dogs"), Prefix("dogs")))))
     assertEquals(mq.mapLastTerm(expandQ), expected)
+  }
+
+  test("MultiQuery.mapLastTerm does nothing for ending minimum-should-match query") {
+    val qs = "(apple banana orange)@2"
+    val mq = Parser.parseQ(qs)
+    assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
+  }
+
+  test("MultiQuery.mapLastTerm does nothing for ending range query") {
+    val qs = "name:[cats TO fs2]"
+    val mq = Parser.parseQ(qs)
+    assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
+  }
+
+  test("MultiQuery.mapLastTerm does nothing for ending group query") {
+    val qs = "cats AND (dogs OR fish)"
+    val mq = Parser.parseQ(qs)
+    assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
   }
 }

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -17,7 +17,6 @@
 package pink.cozydev.lucille
 
 import pink.cozydev.lucille.Query._
-import pink.cozydev.lucille.Parser
 
 class QuerySuite extends munit.FunSuite {
   def expandQ(q: Query): Query =


### PR DESCRIPTION
It now takes `Query.Term => Query`
It's a noop for `MinimumMatch` and `Group` queries
Also it's a noop for all `TermQuery`'s except `Term`

| Query        | Behaviour                        |
|--------------|----------------------------------|
| Or           | Call `mapLastTerm` on last query |
| And          | Call `mapLastTerm` on last query |
| Not          | Call `mapLastTerm` on query      |
| Group        | Do nothing                       |
| UnaryPlus          | Call `mapLastTerm` on query      |
| UnaryMinus          | Call `mapLastTerm` on query      |
| MinimumMatch | Do nothing                       |
| Field        | Call `mapLastTerm` on query      |
| Term | Apply function |
| Other TermQueries | Do nothing |



Resolves https://github.com/cozydev-pink/lucille/issues/34