### PR TITLE
Add `QueryPrinter` for getting a string representation of a Query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: rootjs_2.12 rootjs_2.13 rootjs_3 docs_2.12 docs_2.13 docs_3 rootjvm_2.12 rootjvm_2.13 rootjvm_3 rootnative_2.12 rootnative_2.13 rootnative_3
+          modules-ignore: lucille-benchmarks_2.12 lucille-benchmarks_2.13 lucille-benchmarks_3 rootjs_2.12 rootjs_2.13 rootjs_3 docs_2.12 docs_2.13 docs_3 rootjvm_2.12 rootjvm_2.13 rootjvm_3 rootnative_2.12 rootnative_2.13 rootnative_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   site:

--- a/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
@@ -45,18 +45,6 @@ class QueryPrinterBenchmark {
   }
 
   @Benchmark
-  def orQueries10PrintToString(): String =
-    orQueries10.toString()
-
-  @Benchmark
-  def orQueries1000PrintToString(): String =
-    orQueries1000.toString()
-
-  @Benchmark
-  def termQueriesPrintToString(): Vector[String] =
-    queries.map(_.toString())
-
-  @Benchmark
   def orQueries10Print(): String =
     QueryPrinter.print(orQueries10)
 

--- a/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
@@ -46,6 +46,22 @@ class QueryPrinterBenchmark {
   }
 
   @Benchmark
+  def orQueriesPrintToString(): String =
+    orQueries.toString()
+
+  @Benchmark
+  def termQueriesPrintToString(): Vector[String] =
+    queries.map(_.toString())
+
+  @Benchmark
+  def orQueriesPrintOld(): String =
+    QueryPrinterOld.print(orQueries)
+
+  @Benchmark
+  def termQueriesPrintOld(): Vector[String] =
+    queries.map(QueryPrinterOld.print)
+
+  @Benchmark
   def orQueriesPrint(): String =
     QueryPrinter.print(orQueries)
 

--- a/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
@@ -54,14 +54,6 @@ class QueryPrinterBenchmark {
     queries.map(_.toString())
 
   @Benchmark
-  def orQueriesPrintOld(): String =
-    QueryPrinterOld.print(orQueries)
-
-  @Benchmark
-  def termQueriesPrintOld(): Vector[String] =
-    queries.map(QueryPrinterOld.print)
-
-  @Benchmark
   def orQueriesPrint(): String =
     QueryPrinter.print(orQueries)
 

--- a/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
@@ -21,15 +21,14 @@ import cats.data.NonEmptyList
 class QueryPrinterBenchmark {
   import Query._
 
-  @Param(Array("10", "100", "1000"))
-  var size: Int = 0
-
-  var orQueries: Query = _
+  var orQueries10: Query = _
+  var orQueries1000: Query = _
   var queries: Vector[Query] = Vector.empty
 
   @Setup
   def setup(): Unit = {
-    orQueries = Or(NonEmptyList(Term("o"), (1 to size).map(i => Term(i.toString)).toList))
+    orQueries10 = Or(NonEmptyList(Term("o"), (1 to 10).map(i => Term(i.toString)).toList))
+    orQueries1000 = Or(NonEmptyList(Term("o"), (1 to 1000).map(i => Term(i.toString)).toList))
     queries = Vector(
       Term("term"),
       Phrase("phrase query"),
@@ -46,16 +45,24 @@ class QueryPrinterBenchmark {
   }
 
   @Benchmark
-  def orQueriesPrintToString(): String =
-    orQueries.toString()
+  def orQueries10PrintToString(): String =
+    orQueries10.toString()
+
+  @Benchmark
+  def orQueries1000PrintToString(): String =
+    orQueries1000.toString()
 
   @Benchmark
   def termQueriesPrintToString(): Vector[String] =
     queries.map(_.toString())
 
   @Benchmark
-  def orQueriesPrint(): String =
-    QueryPrinter.print(orQueries)
+  def orQueries10Print(): String =
+    QueryPrinter.print(orQueries10)
+
+  @Benchmark
+  def orQueries1000Print(): String =
+    QueryPrinter.print(orQueries1000)
 
   @Benchmark
   def termQueriesPrint(): Vector[String] =

--- a/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
@@ -1,0 +1,41 @@
+package pink.cozydev.lucille
+package benchmarks
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+import pink.cozydev.lucille.Query
+import pink.cozydev.lucille.QueryPrinter
+import pink.cozydev.lucille.QueryParser
+
+/** To run the benchmark from within sbt:
+  *
+  * jmh:run -i 10 -wi 10 -f 2 -t 1 pink.cozydev.lucille.benchmarks.QueryPrinterBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread". Please note that
+  * benchmarks should be usually executed at least in 10 iterations (as a rule of thumb), but
+  * more is better.
+  */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class QueryPrinterBenchmark {
+
+  var queries: List[Query] = _
+  @Setup
+  def setup(): Unit = {
+    val qs = List(
+      "hi hello this is a large multi term query with several different words",
+      "one AND two AND three OR four OR five AND six OR seven AND eight OR nine AND ten",
+      "(multiple terms)@2 OR title:\"The Title\" AND age:[10 TO 30}",
+      "something AND ((multiple terms)@2 OR title:\"The Title\" AND age:[10 TO 30}) OR fuzzy~2",
+    )
+    queries = qs.map(QueryParser.parse).map(_.toOption.get)
+  }
+
+
+  @Benchmark
+  def printer(): List[String] =
+    queries.map(QueryPrinter.print)
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,14 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
     ),
   )
 
+lazy val benchmarks = project
+  .in(file("benchmarks"))
+  .dependsOn(core.jvm)
+  .settings(
+    name := "lucille-benchmarks"
+  )
+  .enablePlugins(NoPublishPlugin, JmhPlugin)
+
 import laika.ast.Path.Root
 import laika.helium.config.{IconLink, HeliumIcon, TextLink, ThemeNavigationSection}
 lazy val docs = project

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.lucille
+
+import pink.cozydev.lucille.Query._
+import cats.syntax.all._
+
+object QueryPrinter {
+  def print(query: Query): String =
+    query match {
+      case q: MultiQuery => q.qs.map(print).mkString_(" ")
+      case q: TermQuery => strTermQuery(q)
+      case q: Or => q.qs.map(print).mkString_(" OR ")
+      case q: And => q.qs.map(print).mkString_(" AND ")
+      case q: Not => "NOT " + print(q.q)
+      case q: Group => q.qs.map(print).mkString_("(", " ", ")")
+      case q: UnaryPlus => "+" + print(q.q)
+      case q: UnaryMinus => "-" + print(q.q)
+      case q: MinimumMatch => q.qs.map(print).mkString_("(", " ", s")@${q.num}")
+      case q: Field => q.field + ":" + print(q.q)
+    }
+
+  def strTermQuery(q: TermQuery): String =
+    q match {
+      case q: Term => q.str
+      case q: Phrase => "\"" + q.str + "\""
+      case q: Prefix => q.str + "*"
+      case q: Proximity => "\"" + q.str + "\"~" + q.num
+      case q: Fuzzy => s"${q.str}~${q.num.getOrElse("")}"
+      case q: TermRegex => q.str // TODO slashes?
+      case q: TermRange =>
+        val lft = if (q.lowerInc) "{" else "["
+        val rgt = if (q.upperInc) "}" else "]"
+        val parts = lft :: q.lower.getOrElse("*") :: " TO " :: q.upper.getOrElse("*") :: rgt :: Nil
+        parts.mkString
+    }
+
+}

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -17,39 +17,7 @@
 package pink.cozydev.lucille
 
 import pink.cozydev.lucille.Query._
-import cats.syntax.all._
 import cats.data.NonEmptyList
-
-object QueryPrinterOld {
-  def print(query: Query): String =
-    query match {
-      case q: MultiQuery => q.qs.map(print).mkString_(" ")
-      case q: TermQuery => strTermQuery(q)
-      case q: Or => q.qs.map(print).mkString_(" OR ")
-      case q: And => q.qs.map(print).mkString_(" AND ")
-      case q: Not => "NOT " + print(q.q)
-      case q: Group => q.qs.map(print).mkString_("(", " ", ")")
-      case q: UnaryPlus => "+" + print(q.q)
-      case q: UnaryMinus => "-" + print(q.q)
-      case q: MinimumMatch => q.qs.map(print).mkString_("(", " ", s")@${q.num}")
-      case q: Field => q.field + ":" + print(q.q)
-    }
-
-  def strTermQuery(q: TermQuery): String =
-    q match {
-      case q: Term => q.str
-      case q: Phrase => "\"" + q.str + "\""
-      case q: Prefix => q.str + "*"
-      case q: Proximity => "\"" + q.str + "\"~" + q.num
-      case q: Fuzzy => s"${q.str}~${q.num.getOrElse("")}"
-      case q: TermRegex => q.str // TODO slashes?
-      case q: TermRange =>
-        val lft = if (q.lowerInc) "{" else "["
-        val rgt = if (q.upperInc) "}" else "]"
-        val parts = lft :: q.lower.getOrElse("*") :: " TO " :: q.upper.getOrElse("*") :: rgt :: Nil
-        parts.mkString
-    }
-}
 
 object QueryPrinter {
 

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -18,8 +18,9 @@ package pink.cozydev.lucille
 
 import pink.cozydev.lucille.Query._
 import cats.syntax.all._
+import cats.data.NonEmptyList
 
-object QueryPrinter {
+object QueryPrinterOld {
   def print(query: Query): String =
     query match {
       case q: MultiQuery => q.qs.map(print).mkString_(" ")
@@ -48,5 +49,79 @@ object QueryPrinter {
         val parts = lft :: q.lower.getOrElse("*") :: " TO " :: q.upper.getOrElse("*") :: rgt :: Nil
         parts.mkString
     }
+}
 
+object QueryPrinter {
+
+  def print(query: Query): String = {
+    val sb = new StringBuilder()
+
+    def printQ(query: Query): Unit =
+      query match {
+        case q: MultiQuery => printEachNel(q.qs, " ")
+        case q: TermQuery => strTermQuery(q)
+        case q: Or => printEachNel(q.qs, " OR ")
+        case q: And => printEachNel(q.qs, " AND ")
+        case q: Not =>
+          sb.append("NOT ")
+          printQ(q.q)
+        case q: Group =>
+          sb.append('(')
+          printEachNel(q.qs, " ")
+          sb.append(')')
+        case q: UnaryPlus =>
+          sb.append('+')
+          printQ(q.q)
+        case q: UnaryMinus =>
+          sb.append('-')
+          printQ(q.q)
+        case q: MinimumMatch =>
+          sb.append('(')
+          printEachNel(q.qs, " ")
+          sb.append(s")@${q.num}")
+        case q: Field =>
+          sb.append(q.field)
+          sb.append(':')
+          printQ(q.q)
+      }
+
+    def strTermQuery(q: TermQuery): Unit =
+      q match {
+        case q: Term => sb.append(q.str)
+        case q: Phrase =>
+          sb.append('"')
+          sb.append(q.str)
+          sb.append('"')
+        case q: Prefix =>
+          sb.append(q.str)
+          sb.append('*')
+        case q: Proximity =>
+          sb.append('"')
+          sb.append(q.str)
+          sb.append("\"~")
+          sb.append(q.num.toString())
+        case q: Fuzzy =>
+          sb.append(q.str)
+          sb.append('~')
+          q.num.foreach(i => sb.append(i.toString()))
+        case q: TermRegex => sb.append(q.str)
+        case q: TermRange =>
+          if (q.lowerInc) sb.append('{') else sb.append('[')
+          sb.append(q.lower.getOrElse("*"))
+          sb.append(" TO ")
+          sb.append(q.upper.getOrElse("*"))
+          if (q.upperInc) sb.append('}') else sb.append(']')
+      }
+
+    def printEachNel(nel: NonEmptyList[Query], sep: String): Unit = {
+      printQ(nel.head)
+      nel.tail.foreach { q =>
+        sb.append(sep)
+        printQ(q)
+      }
+    }
+
+    printQ(query)
+    sb.result()
+  }
 }

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.lucille
+
+import pink.cozydev.lucille.Query._
+import cats.data.NonEmptyList
+
+class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
+
+  test("prints MultiQuery query") {
+    val q = MultiQuery(NonEmptyList.of(Term("hello"), Term("hi")))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "hello hi")
+  }
+
+  test("prints OR query") {
+    val q = Or(NonEmptyList.of(Term("hello"), Term("hi")))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "hello OR hi")
+  }
+
+  test("prints AND query") {
+    val q = And(NonEmptyList.of(Term("hello"), Term("hi")))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "hello AND hi")
+  }
+
+  test("prints Not query") {
+    val q = Not(Group(NonEmptyList.of(Term("hello"), Term("hi"))))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "NOT (hello hi)")
+  }
+
+  test("prints Group query") {
+    val q = Group(NonEmptyList.of(Term("hello"), Term("hi")))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "(hello hi)")
+  }
+
+  test("prints UnaryMinus query") {
+    val q = UnaryMinus(Term("hello"))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "-hello")
+  }
+
+  test("prints UnaryPlus query") {
+    val q = UnaryPlus(Term("hello"))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "+hello")
+  }
+
+  test("prints MinimumMatch query") {
+    val q = MinimumMatch(NonEmptyList.of(Term("hello"), Term("hi")), 2)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "(hello hi)@2")
+  }
+
+  test("prints Field query") {
+    val q = Field("msg", MinimumMatch(NonEmptyList.of(Term("hello"), Term("hi")), 2))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "msg:(hello hi)@2")
+  }
+
+}
+
+class QueryPrinterSimpleQueryTermSuite extends munit.FunSuite {
+
+  test("prints single term") {
+    val q = Term("hello")
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "hello")
+  }
+
+  test("prints phrase") {
+    val q = Phrase("hello friend")
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "\"hello friend\"")
+  }
+
+  test("prints prefix term") {
+    val q = Prefix("hel")
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "hel*")
+  }
+
+  test("prints proximity term") {
+    val q = Proximity("cats jumped", 2)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "\"cats jumped\"~2")
+  }
+
+  test("prints fuzzy (no num) term") {
+    val q = Fuzzy("hello", None)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "hello~")
+  }
+
+  test("prints fuzzy (num) term") {
+    val q = Fuzzy("hello", Some(2))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "hello~2")
+  }
+
+  test("prints regex term") {
+    val q = TermRegex("/.ump(s|ing)/")
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "/.ump(s|ing)/")
+  }
+
+  test("prints term range [* TO *]") {
+    val q = TermRange(None, None, false, false)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "[* TO *]")
+  }
+
+  test("prints term range [Apple TO Banana]") {
+    val q = TermRange(Some("Apple"), Some("Banana"), false, false)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "[Apple TO Banana]")
+  }
+
+  test("prints term range {Apple TO Banana]") {
+    val q = TermRange(Some("Apple"), Some("Banana"), true, false)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "{Apple TO Banana]")
+  }
+
+  test("prints term range [Apple TO Banana}") {
+    val q = TermRange(Some("Apple"), Some("Banana"), false, true)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "[Apple TO Banana}")
+  }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,3 +7,5 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.16")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")


### PR DESCRIPTION
Adds `QueryPrinter` to print out a string representation of a `Query`.

```scala
QueryPrinter.print(Proximity("cats jumped", 2))
```
`"cats jumped"~2`


Resolves https://github.com/cozydev-pink/lucille/issues/107