### PR TITLE
Fix `~` acting as strikethrough in scaladoc

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -84,7 +84,7 @@ object Query {
 
   /** A proximity query
     * Search for words within a specified word distance
-    * e.g. '"cat jumped"~3', '"one two three"~2'
+    * e.g. '"cat jumped"\~3', '"one two three"\~2'
     *
     * @param str the words
     * @param num the word distance
@@ -92,7 +92,7 @@ object Query {
   final case class Proximity(str: String, num: Int) extends TermQuery
 
   /** A fuzzy query with an optional distance value
-    * e.g. 'cat~', 'cat~1'
+    * e.g. 'cat\~', 'cat\~1'
     *
     * @param str the string
     * @param num the number of edits allowed

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -71,7 +71,7 @@ private object Parser {
   val proxSoft: P[String] = phrase.soft <* pchar('~')
 
   /** Parse a proximity query
-    * e.g. '"cat jumped"~3', '"one two three"~2'
+    * e.g. '"cat jumped"\~3', '"one two three"\~2'
     */
   val proximityQ: P[Proximity] = (proxSoft ~ int).map { case (p, n) =>
     Proximity(p, n)
@@ -80,7 +80,7 @@ private object Parser {
   val fuzzySoft: P[String] = term.soft <* pchar('~')
 
   /** Parse a fuzzy term query
-    * e.g. 'cat~', 'cat~1'
+    * e.g. 'cat\~', 'cat\~1'
     */
   val fuzzyT: P[Fuzzy] = (fuzzySoft ~ int.?).map { case (q, n) =>
     Fuzzy(q, n)


### PR DESCRIPTION
Prior to this the scaladoc formatting what using a strikethrough from the first `~` to the last.