### PR TITLE
Add support for Boost queries

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -200,6 +200,17 @@ object Query {
       UnaryMinus(q.mapLastTerm(f))
   }
 
+  /** A query with a boost weight
+    * Search for documents with the underlying query as usual, the boost is only used in scoring
+    * e.g. 'cats^2 OR dogs^3.1'
+    *
+    * @param q the query
+    * @param boost the boost weight
+    */
+  final case class Boost(q: Query, boost: Float) extends Query {
+    def mapLastTerm(f: Query.Term => Query): Boost = this
+  }
+
   /** A minimum match query
     * Search for documents that match at least `num` of the given queries
     * e.g. '(one two three)@2'

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -46,10 +46,17 @@ private object Parser {
   val spaces: P[Unit] = P.charIn(Set(' ', '\t')).rep.void
   val maybeSpace: Parser0[Unit] = spaces.?.void
   val int: P[Int] = (digit.rep <* P.not(P.char('.'))).string.map(_.toInt)
+
+  def parseFloat(s: String): Option[Float] =
+    try Option(java.lang.Float.parseFloat(s))
+    catch {
+      case _: NumberFormatException => None
+    }
+
   val float: P[Float] = {
     val dotDigits = P.char('.') *> digit.rep
     val fs = (digit.rep ~ dotDigits.?).string
-    fs.mapFilter(_.toFloatOption).withContext("float")
+    fs.mapFilter(parseFloat).withContext("float")
   }
 
   private val baseRange = (0x20.toChar to 0x10ffff.toChar).toSet

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -47,6 +47,10 @@ object QueryPrinter {
           sb.append('(')
           printEachNel(q.qs, " ")
           sb.append(s")@${q.num}")
+        case q: Boost =>
+          sb.append('(')
+          printQ(q.q)
+          sb.append(s")^${q.boost}")
         case q: Field =>
           sb.append(q.field)
           sb.append(':')

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -48,14 +48,27 @@ object QueryPrinter {
           printEachNel(q.qs, " ")
           sb.append(s")@${q.num}")
         case q: Boost =>
-          sb.append('(')
-          printQ(q.q)
-          sb.append(s")^%.${precision}f".format(q.boost))
+          printBoostQuery(q)
         case q: Field =>
           sb.append(q.field)
           sb.append(':')
           printQ(q.q)
       }
+
+    def printBoostQuery(q: Boost): Unit = {
+      val boostStr = s"%.${precision}f".format(q.boost)
+      q.q match {
+        case q: Group => printQ(q)
+        case q: Phrase => strTermQuery(q)
+        case q: Term => strTermQuery(q)
+        case qq =>
+          sb.append('(')
+          printQ(qq)
+          sb.append(')')
+      }
+      sb.append('^')
+      sb.append(boostStr)
+    }
 
     def strTermQuery(q: TermQuery): Unit =
       q match {

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -21,7 +21,7 @@ import cats.data.NonEmptyList
 
 object QueryPrinter {
 
-  def print(query: Query): String = {
+  def print(query: Query, precision: Int = 2): String = {
     val sb = new StringBuilder()
 
     def printQ(query: Query): Unit =
@@ -50,7 +50,7 @@ object QueryPrinter {
         case q: Boost =>
           sb.append('(')
           printQ(q.q)
-          sb.append(s")^${q.boost}")
+          sb.append(s")^%.${precision}f".format(q.boost))
         case q: Field =>
           sb.append(q.field)
           sb.append(':')

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -21,6 +21,18 @@ import cats.data.NonEmptyList
 
 object QueryPrinter {
 
+  /** Builds a string representation of a `Query`.
+    * `Boost` query values are rounded to `precision`.
+    *
+    * @example {{{
+    * scala> QueryPrinter.print(Boost(Phrase("apple pi"), 3.14159f), 3)
+    * res0: String = "apple pi"^3.142
+    * }}}
+    *
+    * @param query query to format
+    * @param precision restricts the number of characters after the decimal
+    * @return
+    */
   def print(query: Query, precision: Int = 2): String = {
     val sb = new StringBuilder()
 

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -112,6 +112,17 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
     assertSingleTerm(r, Field("fieldName42", Boost(Term("cat42"), 3.1f)))
   }
 
+  test("parse boost does not parse with trailing 'f' on boost".fail) {
+    // TODO the trailing `f` is parsing as another term and it should not
+    val r = parseQ("fieldName42:cat42^3.1f")
+    assert(r.isLeft)
+  }
+
+  test("parse boost does not parse with trailing 'd' on boost".fail) {
+    val r = parseQ("fieldName42:cat42^3.1d")
+    assert(r.isLeft)
+  }
+
 }
 
 class MultiSimpleQuerySuite extends munit.FunSuite {

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -102,6 +102,16 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
     assert(r.isLeft)
   }
 
+  test("parse boost on term query") {
+    val r = parseQ("cats^3.0")
+    assertSingleTerm(r, Boost(Term("cats"), 3f))
+  }
+
+  test("parse multiple boost on term queries") {
+    val r = parseQ("cats^3.0 AND dogs^2")
+    assertSingleTerm(r, And(Boost(Term("cats"), 3f), Boost(Term("dogs"), 2f)))
+  }
+
   test("parse boost on field query") {
     val r = parseQ("fieldName42:cat42^3")
     assertSingleTerm(r, Field("fieldName42", Boost(Term("cat42"), 3f)))
@@ -110,6 +120,11 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
   test("parse boost on field query using boost with decimal point") {
     val r = parseQ("fieldName42:cat42^3.1")
     assertSingleTerm(r, Field("fieldName42", Boost(Term("cat42"), 3.1f)))
+  }
+
+  test("parse boost on field query with group query") {
+    val r = parseQ("fieldName42:(cats AND dogs)^20")
+    assertSingleTerm(r, Field("fieldName42", Boost(Group(And(Term("cats"), Term("dogs"))), 20f)))
   }
 
   test("parse boost does not parse with trailing 'f' on boost".fail) {

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -102,6 +102,12 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
     assert(r.isLeft)
   }
 
+  test("parse boost on field query") {
+    val r = parseQ("fieldName42:cat42^3")
+    // assertSingleTerm(r, Boost(Field("fieldName42", Term("cat42")), 3f))
+    assertSingleTerm(r, Field("fieldName42", Boost(Term("cat42"), 3f)))
+  }
+
 }
 
 class MultiSimpleQuerySuite extends munit.FunSuite {

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -104,8 +104,12 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
 
   test("parse boost on field query") {
     val r = parseQ("fieldName42:cat42^3")
-    // assertSingleTerm(r, Boost(Field("fieldName42", Term("cat42")), 3f))
     assertSingleTerm(r, Field("fieldName42", Boost(Term("cat42"), 3f)))
+  }
+
+  test("parse boost on field query using boost with decimal point") {
+    val r = parseQ("fieldName42:cat42^3.1")
+    assertSingleTerm(r, Field("fieldName42", Boost(Term("cat42"), 3.1f)))
   }
 
 }

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -69,16 +69,46 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
     assertEquals(str, "(hello hi)@2")
   }
 
+  test("prints single term with boost") {
+    val q = Boost(Term("hello"), 2.25f)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "hello^2.25")
+  }
+
+  test("prints phrase query with boost") {
+    val q = Boost(Phrase("hello friend"), 2.25f)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "\"hello friend\"^2.25")
+  }
+
   test("prints Boost query") {
     val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 2.25f)
     val str = QueryPrinter.print(q)
     assertEquals(str, "(hello OR hi)^2.25")
   }
 
+  test("prints query with multiple boosts") {
+    val q = And(Boost(Term("cats"), 3f), Boost(Term("dogs"), 2f))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "cats^3.00 AND dogs^2.00")
+  }
+
+  test("prints Boost query with precision zero") {
+    val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 3.1f)
+    val str = QueryPrinter.print(q, 0)
+    assertEquals(str, "(hello OR hi)^3")
+  }
+
   test("prints Boost query with precision") {
     val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 3.1f)
     val str = QueryPrinter.print(q, 1)
     assertEquals(str, "(hello OR hi)^3.1")
+  }
+
+  test("prints Boost query with group") {
+    val q = Boost(Group(Term("hello"), Field("fieldB", Term("d"))), 3.1f)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "(hello fieldB:d)^3.10")
   }
 
   test("prints Boost query with other queries included") {

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -71,7 +71,7 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
 
   test("prints Boost query") {
     val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 3.1f)
-    val str = QueryPrinter.print(q)
+    val str = QueryPrinter.print(q, 1)
     assertEquals(str, "(hello OR hi)^3.1")
   }
 

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -69,6 +69,12 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
     assertEquals(str, "(hello hi)@2")
   }
 
+  test("prints Boost query") {
+    val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 3.1f)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "(hello OR hi)^3.1")
+  }
+
   test("prints Field query") {
     val q = Field("msg", MinimumMatch(NonEmptyList.of(Term("hello"), Term("hi")), 2))
     val str = QueryPrinter.print(q)

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -70,9 +70,27 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
   }
 
   test("prints Boost query") {
+    val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 2.25f)
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "(hello OR hi)^2.25")
+  }
+
+  test("prints Boost query with precision") {
     val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 3.1f)
     val str = QueryPrinter.print(q, 1)
     assertEquals(str, "(hello OR hi)^3.1")
+  }
+
+  test("prints Boost query with other queries included") {
+    val q = Or(
+      Boost(
+        Or(Field("fieldA", Group(NonEmptyList.of(Or(Term("a"), Term("b")), Not(Term("c")))))),
+        2.50f,
+      ),
+      Field("fieldB", Term("d")),
+    )
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "(fieldA:(a OR b NOT c))^2.50 OR fieldB:d")
   }
 
   test("prints Field query") {

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -204,14 +204,27 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     )
   }
 
-  test("jones^2 OR smith^0.5".fail) {
+  test("jones^2 OR smith^0.5") {
     val r = parseQ("jones^2 OR smith^0.5")
-    assert(r.isRight)
+    assertEquals(
+      r,
+      Right(MultiQuery(Or(Boost(Term("jones"), 2f), Boost(Term("smith"), 0.5f)))),
+    )
   }
 
-  test("field:(a OR b NOT c)^2.5 OR field:d".fail) {
+  test("field:(a OR b NOT c)^2.5 OR field:d") {
     val r = parseQ("field:(a OR b NOT c)^2.5 OR field:d")
-    assert(r.isRight)
+    assertEquals(
+      r,
+      Right(
+        MultiQuery(
+          Or(
+            Field("field", Boost(Group(Or(Term("a"), Term("b")), Not(Term("c"))), 2.5f)),
+            Field("field", Term("d")),
+          )
+        )
+      ),
+    )
   }
 
   test("""\:\(quoted\+term\)\:""".fail) {


### PR DESCRIPTION
Add boost queries!

`"fieldName42:cat42^3"` -> `Field("fieldName42", Boost(Term("cat42"), 3f))`

Resolves https://github.com/cozydev-pink/lucille/issues/14