### PR TITLE
Parse queryEnd for boost + minimum match

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -66,6 +66,8 @@ private object Parser {
     P.charIn(baseRange -- special)
   val reserved = Set("OR", "||", "AND", "&&", "NOT", "+", "-", "/")
 
+  val queryEnd = (wsp | P.end | P.char(')')).peek
+
   val term: P[String] = P.not(P.stringIn(reserved)).with1 *> allowed.rep.string
 
   /** Parse a term query
@@ -153,16 +155,16 @@ private object Parser {
     */
   def boostQ(query: P[Query]): P[Boost] = {
     val limitedQ = fieldQuery(query) | termQ | phraseQ | groupQ(query)
-    (limitedQ.withContext("limitedQ").soft ~ (P.char('^') *> float <* wsp.orElse(
-      P.end | P.char(')').peek
-    ))).map(qf => Boost(qf._1, qf._2))
+    (limitedQ.withContext("limitedQ").soft ~ (P.char('^') *> float <* queryEnd)).map(qf =>
+      Boost(qf._1, qf._2)
+    )
   }
 
   /**  Parse a minimum match query
     * e.g. '(one two three)@2'
     */
   def minimumMatchQ(query: P[Query]): P[MinimumMatch] = {
-    val matchNum = P.char('@') *> int <* wsp.orElse(P.end | P.char(')').peek)
+    val matchNum = P.char('@') *> int <* queryEnd
     val grouped = nonGrouped(query).between(P.char('('), P.char(')'))
     (grouped.soft ~ matchNum).map { case (qs, n) => MinimumMatch(qs, n) }
   }

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -17,7 +17,7 @@
 package pink.cozydev.lucille
 
 import cats.parse.{Parser => P}
-import cats.parse.Rfc5234.{sp, alpha, digit}
+import cats.parse.Rfc5234.{sp, alpha, digit, wsp}
 import cats.parse.Parser.{char => pchar}
 import cats.data.NonEmptyList
 import cats.parse.Parser0
@@ -43,7 +43,7 @@ private object Parser {
   import Query._
 
   val dquote = P.charIn(Set('"', '“', '”'))
-  val spaces: P[Unit] = P.charIn(Set(' ', '\t')).rep.void
+  val spaces: P[Unit] = wsp.rep.void
   val maybeSpace: Parser0[Unit] = spaces.?.void
   val int: P[Int] = (digit.rep <* P.not(P.char('.'))).string.map(_.toInt)
 

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -127,13 +127,13 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
     assertSingleTerm(r, Field("fieldName42", Boost(Group(And(Term("cats"), Term("dogs"))), 20f)))
   }
 
-  test("parse boost does not parse with trailing 'f' on boost".fail) {
+  test("parse boost does not parse with trailing 'f' on boost") {
     // TODO the trailing `f` is parsing as another term and it should not
     val r = parseQ("fieldName42:cat42^3.1f")
     assert(r.isLeft)
   }
 
-  test("parse boost does not parse with trailing 'd' on boost".fail) {
+  test("parse boost does not parse with trailing 'd' on boost") {
     val r = parseQ("fieldName42:cat42^3.1d")
     assert(r.isLeft)
   }

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -117,6 +117,11 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
     assertSingleTerm(r, Field("fieldName42", Boost(Term("cat42"), 3f)))
   }
 
+  test("parse boost on field query in a group query") {
+    val r = parseQ("(fieldName42:cat42^3)")
+    assertSingleTerm(r, Group(Field("fieldName42", Boost(Term("cat42"), 3f))))
+  }
+
   test("parse boost on field query using boost with decimal point") {
     val r = parseQ("fieldName42:cat42^3.1")
     assertSingleTerm(r, Field("fieldName42", Boost(Term("cat42"), 3.1f)))

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -133,7 +133,6 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
   }
 
   test("parse boost does not parse with trailing 'f' on boost") {
-    // TODO the trailing `f` is parsing as another term and it should not
     val r = parseQ("fieldName42:cat42^3.1f")
     assert(r.isLeft)
   }


### PR DESCRIPTION
Resolves #113 

- switches our `spaces` parser to use `wsp`, it's the exact same definition
- add a `queryEnd` definition; queries can end with whitespace, the end of the string, or the end of a group (`)`)
- ensure we hit a `queryEnd` in our boost and minimum match queries