### PR TITLE
Allow more whitespace in phrase queries

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -75,7 +75,7 @@ private object Parser {
     */
   val termQ: P[Term] = term.map(Term.apply)
 
-  val phrase: P[String] = (term ~ sp.?).rep.string.surroundedBy(dquote)
+  val phrase: P[String] = (maybeSpace.with1 *> term <* maybeSpace).rep.string.surroundedBy(dquote)
 
   /** Parse a phrase query
     * e.g. 'the cat jumped'

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -52,6 +52,21 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
     assertSingleTerm(r, Phrase("The cat jumped"))
   }
 
+  test("parse phrase term with inner trailing whitespace") {
+    val r = parseQ("\"The cat jumped   \"")
+    assertSingleTerm(r, Phrase("The cat jumped   "))
+  }
+
+  test("parse phrase term with inner leading whitespace") {
+    val r = parseQ("\"   The cat jumped\"")
+    assertSingleTerm(r, Phrase("   The cat jumped"))
+  }
+
+  test("parse phrase term with inner leading and trailing and mixed whitespace") {
+    val r = parseQ("\"   The  cat jumped   \"")
+    assertSingleTerm(r, Phrase("   The  cat jumped   "))
+  }
+
   test("parse phrase term with smart quotes") {
     val r = parseQ("“The cat jumped”")
     assertSingleTerm(r, Phrase("The cat jumped"))


### PR DESCRIPTION
Modifies the parser to allow multiple occurrences of whitespace within a phrase query at the start and end of terms.
Previously a query like `"this guide is for "` (with the trailing whitespace) would fail.


Also we add more tests to catch these cases.