### PR TITLE
Add docs examples for QueryPrinter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,18 @@ import pink.cozydev.lucille.QueryPrinter
 QueryPrinter.print(Query.And(Query.Term("cats"), Query.Term("dogs")))
 ```
 
+Because the numeric value of a query boost parameter is modelled as a `Float`, the query printer
+has a `precision` parameter it uses to round the boost parameter for pretty printing:
+
+```scala mdoc
+val queryWithBoost = Query.Boost(Query.Phrase("apple pi"), 3.14159265f)
+
+// the default precision is 2
+QueryPrinter.print(queryWithBoost)
+
+QueryPrinter.print(queryWithBoost, precision=5)
+```
+
 ### Last Query Rewriting
 
 To enable a better interactive search experience, it can be helpful to rewrite the last term as a

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,17 @@ import pink.cozydev.lucille.QueryParser
 QueryParser.parse("cats OR dogs")
 ```
 
+### Printing
+
+Lucille offers a `printer` to format `Query`s as Lucene query strings:
+
+```scala mdoc
+import pink.cozydev.lucille.Query
+import pink.cozydev.lucille.QueryPrinter
+
+QueryPrinter.print(Query.And(Query.Term("cats"), Query.Term("dogs")))
+```
+
 ### Last Query Rewriting
 
 To enable a better interactive search experience, it can be helpful to rewrite the last term as a


### PR DESCRIPTION
Adds some basic examples of query printing to the site docs.
Resolves https://github.com/cozydev-pink/lucille/issues/139

<img width="804" alt="Screen Shot 2024-05-16 at 5 39 01 PM" src="https://github.com/cozydev-pink/lucille/assets/5440389/9713b0f7-2e81-465b-92a7-61d5bd90c7bd">
