### PR TITLE
Ensuring we always have a known boolean operator

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -170,12 +170,8 @@ object Query {
     *
     * @param qs the queries to group
     */
-  final case class Group(qs: NonEmptyList[Query]) extends Query {
+  final case class Group(q: Query) extends Query {
     def mapLastTerm(f: Query.Term => Query): Group = this
-  }
-  object Group {
-    def apply(head: Query, tail: Query*): Group =
-      Group(NonEmptyList(head, tail.toList))
   }
 
   /** A unary plus query

--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -35,26 +35,6 @@ sealed trait TermQuery extends Query {
   def mapLastTerm(f: Query.Term => Query): Query = this
 }
 
-/** A trait for a list of one or more queries
-  *
-  * @param qs the queries
-  */
-final case class MultiQuery(qs: NonEmptyList[Query]) extends Query {
-
-  def mapLastTerm(f: Query.Term => Query): MultiQuery = {
-    val newLast: Query = qs.last.mapLastTerm(f)
-    if (qs.size == 1) MultiQuery(NonEmptyList.one(newLast))
-    else {
-      val newT = qs.tail.init :+ newLast
-      MultiQuery(NonEmptyList(qs.head, newT))
-    }
-  }
-}
-object MultiQuery {
-  def apply(head: Query, tail: Query*): MultiQuery =
-    MultiQuery(NonEmptyList(head, tail.toList))
-}
-
 object Query {
 
   /** A term query

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -162,8 +162,8 @@ object QueryParser {
   val defaultParser = new QueryParser(defaultBooleanOR = true)
 
   /** Attempt to parse a whole string representing a Lucene query */
-  def parse(input: String): Either[String, MultiQuery] =
-    defaultParser.parse(input).map(q => MultiQuery(q))
+  def parse(input: String): Either[String, Query] =
+    defaultParser.parse(input)
 
 }
 

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -243,9 +243,4 @@ private object Parser {
   /** Parse one or more queries implicitly grouped together in a list
     */
   val fullQuery = nonGrouped(recursiveQ) <* maybeSpace
-
-  /** Attempt to parse a whole string representing a Lucene query
-    */
-  def parseQ(s: String): Either[cats.parse.Parser.Error, MultiQuery] =
-    fullQuery.parseAll(s).map(MultiQuery.apply)
 }

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -24,6 +24,118 @@ import cats.parse.Parser0
 import cats.syntax.all._
 import internal.Op
 
+class QueryParser(
+    defaultBooleanOR: Boolean
+) {
+  import Query._
+  import Parser._
+
+  /** Parse a suffix op query
+    * e.g. 'OR term1 OR term2$' parses completely
+    * however 'OR term1 OR term2 extra$' parses until the end of 'term2', with 'extra' being left
+    */
+  private def suffixOps(query: P[Query]): Parser0[List[(Op, Query)]] =
+    ((maybeSpace.with1 *> infixOp <* sp.rep) ~ query)
+      .repUntil0(maybeSpace *> (P.end | query))
+
+  /** Parse simple queries followed by suffix op queries
+    * e.g. 'q0 q1 OR q2'
+    */
+  private def qWithSuffixOps(query: P[Query]): P[NonEmptyList[Query]] =
+    (query.repSep(sp.rep) ~ suffixOps(query))
+      .map { case (h, t) => internal.Op.associateOps(h, t, defaultBooleanOR) }
+
+  /** Parse a whole list of queries
+    * e.g. 'q0 q1 OR q2 q3'
+    * Parsing repeats so that we can parse q3, the first iteration only gets 'q0 q1 OR q2'
+    */
+  private def nonGrouped(query: P[Query]): P[NonEmptyList[Query]] =
+    (maybeSpace.with1 *> qWithSuffixOps(query)).repUntil(maybeSpace ~ P.end).map(_.flatten)
+
+  /** Parse a not query
+    * e.g. 'animals NOT (cats AND dogs)'
+    */
+  private def notQ(query: P[Query]): P[Query] =
+    ((P.string("NOT").soft ~ maybeSpace) *> query).map(Not.apply)
+
+  /**  Parse a boost query
+    * e.g. 'cats^2', '(dogs)^3.1', 'field:term^2.5'
+    */
+  private def boostQ(query: P[Query]): P[Boost] = {
+    val limitedQ = fieldQuery(query) | termQ | phraseQ | groupQ(query)
+    (limitedQ.withContext("limitedQ").soft ~ (P.char('^') *> float <* queryEnd)).map(qf =>
+      Boost(qf._1, qf._2)
+    )
+  }
+
+  /**  Parse a minimum match query
+    * e.g. '(one two three)@2'
+    */
+  private def minimumMatchQ(query: P[Query]): P[MinimumMatch] = {
+    val matchNum = P.char('@') *> int <* queryEnd
+    val grouped = nonGrouped(query).between(P.char('('), P.char(')'))
+    (grouped.soft ~ matchNum).map { case (qs, n) => MinimumMatch(qs, n) }
+  }
+
+  /**  Parse a group query
+    * e.g. '(cats AND dogs)'
+    */
+  private def groupQ(query: P[Query]): P[Group] = {
+    val g = nonGrouped(query)
+      .between(P.char('('), P.char(')'))
+    val endOfGroupSpecial = P.char('@')
+    (g <* P.not(endOfGroupSpecial)).map(Group.apply)
+  }
+
+  /** Parse a field query
+    * e.g. 'title:cats', 'author:"Silly Goose"', 'title:(cats AND dogs)'
+    */
+  private val fieldValueSoft: P[String] = term.soft <* pchar(':')
+  private def fieldQuery(query: P[Query]): P[Field] =
+    (fieldValueSoft ~ query).map { case (f, q) => Field(f, q) }
+
+  /** Parse a unary plus query
+    * e.g. '+cat', '+(cats AND dogs)'
+    */
+  private def unaryPlus(query: P[Query]): P[UnaryPlus] =
+    P.char('+') *> query.map(UnaryPlus.apply)
+
+  /** Parse a unary minus query
+    * e.g. 'cat'*, '-(cats AND dogs)'
+    */
+  private def unaryMinus(query: P[Query]): P[UnaryMinus] =
+    P.char('-') *> query.map(UnaryMinus.apply)
+
+  /** Recursively parse compound queries
+    * The order is very important:
+    * - prefixT must come before termQ
+    */
+  private val recursiveQ: P[Query] = P.recursive[Query](r =>
+    P.oneOf(
+      List(
+        unaryPlus(r),
+        unaryMinus(r),
+        notQ(r),
+        fieldQuery(r),
+        proximityQ,
+        rangeQuery,
+        fuzzyT,
+        prefixT,
+        minimumMatchQ(r),
+        boostQ(r),
+        termQ,
+        regexQ,
+        phraseQ,
+        groupQ(r),
+      )
+    )
+  )
+
+  /** Parse one or more queries implicitly grouped together in a list
+    */
+  val fullQuery = nonGrouped(recursiveQ) <* maybeSpace
+
+}
 object QueryParser {
 
   private def errorMsg(err: cats.parse.Parser.Error): String = {
@@ -31,9 +143,11 @@ object QueryParser {
     s"Parse error at offset ${err.failedAtOffset}, with expectations:\n $exps"
   }
 
+  val defaultParser = new QueryParser(defaultBooleanOR = true)
+
   /** Attempt to parse a whole string representing a Lucene query */
   def parse(input: String): Either[String, MultiQuery] =
-    Parser.fullQuery
+    defaultParser.fullQuery
       .parseAll(input)
       .map(MultiQuery.apply)
       .leftMap(errorMsg)
@@ -119,86 +233,6 @@ private object Parser {
     */
   val regexQ: P[TermRegex] = regex.map(TermRegex.apply)
 
-  val or = (P.string("OR") | P.string("||")).as(internal.Op.OR)
-  val and = (P.string("AND") | P.string("&&")).as(internal.Op.AND)
-  val infixOp = (or | and).withContext("infixOp")
-
-  /** Parse a suffix op query
-    * e.g. 'OR term1 OR term2$' parses completely
-    * however 'OR term1 OR term2 extra$' parses until the end of 'term2', with 'extra' being left
-    */
-  def suffixOps(query: P[Query]): Parser0[List[(Op, Query)]] =
-    ((maybeSpace.with1 *> infixOp <* sp.rep) ~ query)
-      .repUntil0(maybeSpace *> (P.end | query))
-
-  /** Parse simple queries followed by suffix op queries
-    * e.g. 'q0 q1 OR q2'
-    */
-  def qWithSuffixOps(query: P[Query]): P[NonEmptyList[Query]] =
-    (query.repSep(sp.rep) ~ suffixOps(query))
-      .map { case (h, t) => internal.Op.associateOps(h, t) }
-
-  /** Parse a whole list of queries
-    * e.g. 'q0 q1 OR q2 q3'
-    * Parsing repeats so that we can parse q3, the first iteration only gets 'q0 q1 OR q2'
-    */
-  def nonGrouped(query: P[Query]): P[NonEmptyList[Query]] =
-    (maybeSpace.with1 *> qWithSuffixOps(query)).repUntil(maybeSpace ~ P.end).map(_.flatten)
-
-  /** Parse a not query
-    * e.g. 'animals NOT (cats AND dogs)'
-    */
-  def notQ(query: P[Query]): P[Query] =
-    ((P.string("NOT").soft ~ maybeSpace) *> query).map(Not.apply)
-
-  /**  Parse a boost query
-    * e.g. 'cats^2', '(dogs)^3.1', 'field:term^2.5'
-    */
-  def boostQ(query: P[Query]): P[Boost] = {
-    val limitedQ = fieldQuery(query) | termQ | phraseQ | groupQ(query)
-    (limitedQ.withContext("limitedQ").soft ~ (P.char('^') *> float <* queryEnd)).map(qf =>
-      Boost(qf._1, qf._2)
-    )
-  }
-
-  /**  Parse a minimum match query
-    * e.g. '(one two three)@2'
-    */
-  def minimumMatchQ(query: P[Query]): P[MinimumMatch] = {
-    val matchNum = P.char('@') *> int <* queryEnd
-    val grouped = nonGrouped(query).between(P.char('('), P.char(')'))
-    (grouped.soft ~ matchNum).map { case (qs, n) => MinimumMatch(qs, n) }
-  }
-
-  /**  Parse a group query
-    * e.g. '(cats AND dogs)'
-    */
-  def groupQ(query: P[Query]): P[Group] = {
-    val g = nonGrouped(query)
-      .between(P.char('('), P.char(')'))
-    val endOfGroupSpecial = P.char('@')
-    (g <* P.not(endOfGroupSpecial)).map(Group.apply)
-  }
-
-  /** Parse a field query
-    * e.g. 'title:cats', 'author:"Silly Goose"', 'title:(cats AND dogs)'
-    */
-  val fieldValueSoft: P[String] = term.soft <* pchar(':')
-  def fieldQuery(query: P[Query]): P[Field] =
-    (fieldValueSoft ~ query).map { case (f, q) => Field(f, q) }
-
-  /** Parse a unary plus query
-    * e.g. '+cat', '+(cats AND dogs)'
-    */
-  def unaryPlus(query: P[Query]): P[UnaryPlus] =
-    P.char('+') *> query.map(UnaryPlus.apply)
-
-  /** Parse a unary minus query
-    * e.g. 'cat'*, '-(cats AND dogs)'
-    */
-  def unaryMinus(query: P[Query]): P[UnaryMinus] =
-    P.char('-') *> query.map(UnaryMinus.apply)
-
   /** Parse a term range query
     * e.g. '{cats TO dogs}, '[1 TO *}''
     */
@@ -215,32 +249,7 @@ private object Parser {
       }
   }
 
-  /** Recursively parse compound queries
-    * The order is very important:
-    * - prefixT must come before termQ
-    */
-  val recursiveQ: P[Query] = P.recursive[Query](r =>
-    P.oneOf(
-      List(
-        unaryPlus(r),
-        unaryMinus(r),
-        notQ(r),
-        fieldQuery(r),
-        proximityQ,
-        rangeQuery,
-        fuzzyT,
-        prefixT,
-        minimumMatchQ(r),
-        boostQ(r),
-        termQ,
-        regexQ,
-        phraseQ,
-        groupQ(r),
-      )
-    )
-  )
-
-  /** Parse one or more queries implicitly grouped together in a list
-    */
-  val fullQuery = nonGrouped(recursiveQ) <* maybeSpace
+  val or = (P.string("OR") | P.string("||")).as(internal.Op.OR)
+  val and = (P.string("AND") | P.string("&&")).as(internal.Op.AND)
+  val infixOp = (or | and).withContext("infixOp")
 }

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -83,8 +83,7 @@ class QueryParser(
     val g = nonGrouped(query)
       .between(P.char('('), P.char(')'))
     val endOfGroupSpecial = P.char('@')
-    // TODO not NEL
-    (g <* P.not(endOfGroupSpecial)).map(q => Group(NonEmptyList.of(q)))
+    (g <* P.not(endOfGroupSpecial)).map(Group.apply)
   }
 
   /** Parse a suffix op query

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -159,11 +159,15 @@ class QueryParser(
 }
 object QueryParser {
 
-  val defaultParser = new QueryParser(defaultBooleanOR = true)
+  val default = new QueryParser(defaultBooleanOR = true)
+
+  def withDefaultOperatorOR = default
+
+  def withDefaultOperatorAND = new QueryParser(defaultBooleanOR = false)
 
   /** Attempt to parse a whole string representing a Lucene query */
   def parse(input: String): Either[String, Query] =
-    defaultParser.parse(input)
+    default.parse(input)
 
 }
 

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -49,8 +49,6 @@ class QueryParser(
   /**  Parse a minimum match query
     * e.g. '(one two three)@2'
     */
-  // TODO well... this changes things
-  // There really is not an implicit boolean here. it truly is a list!
   private def minimumMatchQ(query: P[Query]): P[MinimumMatch] = {
     val matchNum = P.char('@') *> int <* queryEnd
     val grouped = nonGroupedNEL(query).between(P.char('('), P.char(')'))

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -47,7 +47,7 @@ object QueryPrinter {
           printQ(q.q)
         case q: Group =>
           sb.append('(')
-          printEachNel(q.qs, " ")
+          printQ(q.q)
           sb.append(')')
         case q: UnaryPlus =>
           sb.append('+')

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -38,7 +38,6 @@ object QueryPrinter {
 
     def printQ(query: Query): Unit =
       query match {
-        case q: MultiQuery => printEachNel(q.qs, " ")
         case q: TermQuery => strTermQuery(q)
         case q: Or => printEachNel(q.qs, " OR ")
         case q: And => printEachNel(q.qs, " AND ")

--- a/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
@@ -49,10 +49,10 @@ private[lucille] object Op {
             case (AND, OR) =>
               go(NonEmptyList.of(q), nextOp, tailOpP).prepend(Query.And(acc))
             case (OR, AND) =>
-              // TODO we only get away with not wrapping the `allButLast` in an Or
-              //  because `OR` is the default query type. This should be configurable
-              val allButLast = NonEmptyList(acc.head, acc.tail.dropRight(1))
-              allButLast.concatNel(go(NonEmptyList.of(acc.last, q), nextOp, tailOpP))
+              if (defaultBooleanOR) {
+                val allButLast = NonEmptyList(acc.head, acc.tail.dropRight(1))
+                allButLast.concatNel(go(NonEmptyList.of(acc.last, q), nextOp, tailOpP))
+              } else go(NonEmptyList.of(q), nextOp, tailOpP).prepend(Query.And(acc))
           }
       }
 

--- a/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
@@ -29,7 +29,11 @@ private[lucille] object Op {
     * @param qs suffixOp and query pairs
     * @return
     */
-  def associateOps(q1: NonEmptyList[Query], opQs: List[(Op, Query)]): NonEmptyList[Query] = {
+  def associateOps(
+      q1: NonEmptyList[Query],
+      opQs: List[(Op, Query)],
+      defaultBooleanOR: Boolean,
+  ): NonEmptyList[Query] = {
     def go(acc: NonEmptyList[Query], op: Op, opQs: List[(Op, Query)]): NonEmptyList[Query] =
       opQs match {
         case Nil =>

--- a/core/src/test/scala/pink/cozydev/lucille/DefaultBooleanAndSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/DefaultBooleanAndSuite.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.lucille
+
+import pink.cozydev.lucille.Query._
+
+class DefaultBooleanAndSuite extends munit.FunSuite {
+
+  val parser = new QueryParser(defaultBooleanOR = false)
+  val parseQ = parser.parse(_)
+
+  test("DefaultBooleanAnd two terms") {
+    val actual = parseQ("cats dogs")
+    val expected = And(Term("cats"), Term("dogs"))
+    assertEquals(actual, Right(expected))
+  }
+
+  test("DefaultBooleanAnd many terms") {
+    val actual = parseQ("cats dogs fish lizards")
+    val expected = And(Term("cats"), Term("dogs"), Term("fish"), Term("lizards"))
+    assertEquals(actual, Right(expected))
+  }
+
+  test("DefaultBooleanAnd terms in a group") {
+    val actual = parseQ("(cats dogs)")
+    val expected = Group(And(Term("cats"), Term("dogs")))
+    assertEquals(actual, Right(expected))
+  }
+
+  test("DefaultBooleanAnd terms in a group with explicit AND") {
+    val actual = parseQ("(cats AND dogs)")
+    val expected = Group(And(Term("cats"), Term("dogs")))
+    assertEquals(actual, Right(expected))
+  }
+
+}

--- a/core/src/test/scala/pink/cozydev/lucille/DefaultBooleanAndSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/DefaultBooleanAndSuite.scala
@@ -20,7 +20,7 @@ import pink.cozydev.lucille.Query._
 
 class DefaultBooleanAndSuite extends munit.FunSuite {
 
-  val parser = new QueryParser(defaultBooleanOR = false)
+  val parser = QueryParser.withDefaultOperatorAND
   val parseQ = parser.parse(_)
 
   test("DefaultBooleanAnd two terms") {

--- a/core/src/test/scala/pink/cozydev/lucille/DefaultBooleanAndSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/DefaultBooleanAndSuite.scala
@@ -47,4 +47,10 @@ class DefaultBooleanAndSuite extends munit.FunSuite {
     assertEquals(actual, Right(expected))
   }
 
+  test("DefaultBooleanAnd terms in a group with explicit OR") {
+    val actual = parseQ("(cats OR dogs)")
+    val expected = Group(Or(Term("cats"), Term("dogs")))
+    assertEquals(actual, Right(expected))
+  }
+
 }

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -20,7 +20,7 @@ import Query._
 
 class SingleSimpleQuerySuite extends munit.FunSuite {
 
-  val parseQ = QueryParser.parse
+  val parseQ = QueryParser.parse(_)
 
   def assertSingleTerm(r: Either[String, MultiQuery], expected: Query)(implicit
       loc: munit.Location
@@ -161,7 +161,7 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
 
 class MultiSimpleQuerySuite extends munit.FunSuite {
 
-  val parseQ = QueryParser.parse
+  val parseQ = QueryParser.parse(_)
 
   test("parse multiple terms completely") {
     val r = parseQ("The cat jumped")
@@ -209,7 +209,7 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 
 class QueryWithSuffixOpsSuite extends munit.FunSuite {
 
-  val parseQ = QueryParser.parse
+  val parseQ = QueryParser.parse(_)
 
   test("parse two term OR query completely") {
     val r = parseQ("derp OR lerp")
@@ -394,7 +394,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
 
 class GroupQuerySuite extends munit.FunSuite {
 
-  val parseQ = QueryParser.parse
+  val parseQ = QueryParser.parse(_)
 
   test("parse multiple terms in a group") {
     val r = parseQ("(The cat jumped)")

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -165,19 +165,19 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 
   test("parse multiple terms completely") {
     val r = parseQ("The cat jumped")
-    assertEquals(r, Right(MultiQuery(Term("The"), Term("cat"), Term("jumped"))))
+    assertEquals(r, Right(MultiQuery(Or(Term("The"), Term("cat"), Term("jumped")))))
   }
 
   test("parse multiple terms with lots of spaces completely") {
     val r = parseQ("The cat   jumped   ")
-    assertEquals(r, Right(MultiQuery(Term("The"), Term("cat"), Term("jumped"))))
+    assertEquals(r, Right(MultiQuery(Or(Term("The"), Term("cat"), Term("jumped")))))
   }
 
   test("parse field query and terms completely") {
     val r = parseQ("fieldName:The cat jumped")
     assertEquals(
       r,
-      Right(MultiQuery(Field("fieldName", Term("The")), Term("cat"), Term("jumped"))),
+      Right(MultiQuery(Or(Field("fieldName", Term("The")), Term("cat"), Term("jumped")))),
     )
   }
 
@@ -295,8 +295,11 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         MultiQuery(
-          Term("term"),
-          Or(Term("derp"), Term("lerp")),
+          // TODO unsure if I like this....
+          Or(
+            Term("term"),
+            Or(Term("derp"), Term("lerp")),
+          )
         )
       ),
     )
@@ -308,8 +311,10 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         MultiQuery(
-          Or(Term("derp"), Term("lerp")),
-          Term("slerp"),
+          Or(
+            Or(Term("derp"), Term("lerp")),
+            Term("slerp"),
+          )
         )
       ),
     )
@@ -321,8 +326,10 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         MultiQuery(
-          And(Term("derp"), Term("lerp")),
-          Term("slerp"),
+          Or(
+            And(Term("derp"), Term("lerp")),
+            Term("slerp"),
+          )
         )
       ),
     )
@@ -358,10 +365,12 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
       r,
       Right(
         MultiQuery(
-          And(Term("derp"), Term("lerp")),
-          Term("slerp"),
-          Or(Term("orA"), Term("orB")),
-          Term("last"),
+          Or(
+            And(Term("derp"), Term("lerp")),
+            Term("slerp"),
+            Or(Term("orA"), Term("orB")),
+            Term("last"),
+          )
         )
       ),
     )
@@ -401,7 +410,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Group(Term("The"), Term("cat"), Term("jumped")))
+        MultiQuery(Group(Or(Term("The"), Term("cat"), Term("jumped"))))
       ),
     )
   }
@@ -411,7 +420,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Group(Term("The"), Term("cat"), Term("jumped")))
+        MultiQuery(Group(Or(Term("The"), Term("cat"), Term("jumped"))))
       ),
     )
   }
@@ -422,10 +431,12 @@ class GroupQuerySuite extends munit.FunSuite {
       r,
       Right(
         MultiQuery(
-          Term("animals"),
-          Not(
-            Group(And(Term("cats"), Term("dogs")))
-          ),
+          Or(
+            Term("animals"),
+            Not(
+              Group(And(Term("cats"), Term("dogs")))
+            ),
+          )
         )
       ),
     )
@@ -476,7 +487,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Group(gq), Term("extra"))
+        MultiQuery(Or(Group(gq), Term("extra")))
       ),
     )
   }

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -16,13 +16,13 @@
 
 package pink.cozydev.lucille
 import cats.data.NonEmptyList
-import cats.parse.Parser.Error
 import Query._
-import Parser._
 
 class SingleSimpleQuerySuite extends munit.FunSuite {
 
-  def assertSingleTerm(r: Either[Error, MultiQuery], expected: Query)(implicit
+  val parseQ = QueryParser.parse
+
+  def assertSingleTerm(r: Either[String, MultiQuery], expected: Query)(implicit
       loc: munit.Location
   ) =
     assertEquals(r, Right(MultiQuery(expected)))
@@ -161,6 +161,8 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
 
 class MultiSimpleQuerySuite extends munit.FunSuite {
 
+  val parseQ = QueryParser.parse
+
   test("parse multiple terms completely") {
     val r = parseQ("The cat jumped")
     assertEquals(r, Right(MultiQuery(Term("The"), Term("cat"), Term("jumped"))))
@@ -206,6 +208,8 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 }
 
 class QueryWithSuffixOpsSuite extends munit.FunSuite {
+
+  val parseQ = QueryParser.parse
 
   test("parse two term OR query completely") {
     val r = parseQ("derp OR lerp")
@@ -389,6 +393,8 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
 }
 
 class GroupQuerySuite extends munit.FunSuite {
+
+  val parseQ = QueryParser.parse
 
   test("parse multiple terms in a group") {
     val r = parseQ("(The cat jumped)")

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -22,10 +22,8 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
 
   val parseQ = QueryParser.parse(_)
 
-  def assertSingleTerm(r: Either[String, MultiQuery], expected: Query)(implicit
-      loc: munit.Location
-  ) =
-    assertEquals(r, Right(MultiQuery(expected)))
+  def assertSingleTerm(r: Either[String, Query], expected: Query)(implicit loc: munit.Location) =
+    assertEquals(r, Right(expected))
 
   test("parse single term") {
     val r = parseQ("the")
@@ -89,7 +87,7 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
 
   test("parse field query with phrase") {
     val r = parseQ("fieldName:\"The cat jumped\"")
-    assertEquals(r, Right(MultiQuery(Field("fieldName", Phrase("The cat jumped")))))
+    assertEquals(r, Right(Field("fieldName", Phrase("The cat jumped"))))
   }
 
   test("parse single term with numbers") {
@@ -165,25 +163,25 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 
   test("parse multiple terms completely") {
     val r = parseQ("The cat jumped")
-    assertEquals(r, Right(MultiQuery(Or(Term("The"), Term("cat"), Term("jumped")))))
+    assertEquals(r, Right(Or(Term("The"), Term("cat"), Term("jumped"))))
   }
 
   test("parse multiple terms with lots of spaces completely") {
     val r = parseQ("The cat   jumped   ")
-    assertEquals(r, Right(MultiQuery(Or(Term("The"), Term("cat"), Term("jumped")))))
+    assertEquals(r, Right(Or(Term("The"), Term("cat"), Term("jumped"))))
   }
 
   test("parse field query and terms completely") {
     val r = parseQ("fieldName:The cat jumped")
     assertEquals(
       r,
-      Right(MultiQuery(Or(Field("fieldName", Term("The")), Term("cat"), Term("jumped")))),
+      Right(Or(Field("fieldName", Term("The")), Term("cat"), Term("jumped"))),
     )
   }
 
   test("parse proximity query completely") {
     val r = parseQ("\"derp lerp\"~3")
-    assertEquals(r, Right(MultiQuery(Proximity("derp lerp", 3))))
+    assertEquals(r, Right(Proximity("derp lerp", 3)))
   }
 
   test("parse proximity with decimal does not parse") {
@@ -193,12 +191,12 @@ class MultiSimpleQuerySuite extends munit.FunSuite {
 
   test("parse fuzzy term without number parses completely") {
     val r = parseQ("derp~")
-    assertEquals(r, Right(MultiQuery(Fuzzy("derp", None))))
+    assertEquals(r, Right(Fuzzy("derp", None)))
   }
 
   test("parse fuzzy term with number parses completely") {
     val r = parseQ("derp~2")
-    assertEquals(r, Right(MultiQuery(Fuzzy("derp", Some(2)))))
+    assertEquals(r, Right(Fuzzy("derp", Some(2))))
   }
 
   test("parse fuzzy term with decimal does not parse") {
@@ -216,9 +214,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Or(Term("derp"), Term("lerp"))
-        )
+        Or(Term("derp"), Term("lerp"))
       ),
     )
   }
@@ -228,9 +224,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Or(Term("derp"), Term("lerp"), Term("slerp"))
-        )
+        Or(Term("derp"), Term("lerp"), Term("slerp"))
       ),
     )
   }
@@ -240,9 +234,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Or(Term("derp"), Phrase("lerp slerp"))
-        )
+        Or(Term("derp"), Phrase("lerp slerp"))
       ),
     )
   }
@@ -282,9 +274,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          And(Term("derp"), Term("lerp"))
-        )
+        And(Term("derp"), Term("lerp"))
       ),
     )
   }
@@ -294,12 +284,10 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          // TODO unsure if I like this....
-          Or(
-            Term("term"),
-            Or(Term("derp"), Term("lerp")),
-          )
+        // TODO unsure if I like this....
+        Or(
+          Term("term"),
+          Or(Term("derp"), Term("lerp")),
         )
       ),
     )
@@ -310,11 +298,9 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Or(
-            Or(Term("derp"), Term("lerp")),
-            Term("slerp"),
-          )
+        Or(
+          Or(Term("derp"), Term("lerp")),
+          Term("slerp"),
         )
       ),
     )
@@ -325,11 +311,9 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Or(
-            And(Term("derp"), Term("lerp")),
-            Term("slerp"),
-          )
+        Or(
+          And(Term("derp"), Term("lerp")),
+          Term("slerp"),
         )
       ),
     )
@@ -340,9 +324,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          And(Term("derp"), Phrase("lerp slerp"))
-        )
+        And(Term("derp"), Phrase("lerp slerp"))
       ),
     )
   }
@@ -352,9 +334,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          And(Term("derp"), Phrase("lerp slerp"))
-        )
+        And(Term("derp"), Phrase("lerp slerp"))
       ),
     )
   }
@@ -364,13 +344,11 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Or(
-            And(Term("derp"), Term("lerp")),
-            Term("slerp"),
-            Or(Term("orA"), Term("orB")),
-            Term("last"),
-          )
+        Or(
+          And(Term("derp"), Term("lerp")),
+          Term("slerp"),
+          Or(Term("orA"), Term("orB")),
+          Term("last"),
         )
       ),
     )
@@ -381,9 +359,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Not(Term("derp"))
-        )
+        Not(Term("derp"))
       ),
     )
   }
@@ -393,9 +369,7 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          And(Term("derp"), Not(Term("lerp")))
-        )
+        And(Term("derp"), Not(Term("lerp")))
       ),
     )
   }
@@ -410,7 +384,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Group(Or(Term("The"), Term("cat"), Term("jumped"))))
+        Group(Or(Term("The"), Term("cat"), Term("jumped")))
       ),
     )
   }
@@ -420,7 +394,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Group(Or(Term("The"), Term("cat"), Term("jumped"))))
+        Group(Or(Term("The"), Term("cat"), Term("jumped")))
       ),
     )
   }
@@ -430,13 +404,11 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Or(
-            Term("animals"),
-            Not(
-              Group(And(Term("cats"), Term("dogs")))
-            ),
-          )
+        Or(
+          Term("animals"),
+          Not(
+            Group(And(Term("cats"), Term("dogs")))
+          ),
         )
       ),
     )
@@ -447,11 +419,9 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Field(
-            "title",
-            Group(And(Term("cats"), Term("dogs"))),
-          )
+        Field(
+          "title",
+          Group(And(Term("cats"), Term("dogs"))),
         )
       ),
     )
@@ -462,13 +432,11 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          And(
-            Field("title", Term("test")),
-            Group(
-              Or(Term("pass"), Term("fail"))
-            ),
-          )
+        And(
+          Field("title", Term("test")),
+          Group(
+            Or(Term("pass"), Term("fail"))
+          ),
         )
       ),
     )
@@ -487,7 +455,7 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Or(Group(gq), Term("extra")))
+        Or(Group(gq), Term("extra"))
       ),
     )
   }
@@ -505,11 +473,9 @@ class GroupQuerySuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          And(
-            Group(gq),
-            Phrase("extra phrase"),
-          )
+        And(
+          Group(gq),
+          Phrase("extra phrase"),
         )
       ),
     )

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -20,7 +20,7 @@ import Query._
 // Similar to the SingleSimpleQuerySuite but with a focus on queries with punctuation
 class PunctuationSuite extends munit.FunSuite {
 
-  val parseQ = QueryParser.parse
+  val parseQ = QueryParser.parse(_)
 
   def assertSingleQ(r: Either[String, MultiQuery], expected: Query)(implicit
       loc: munit.Location

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -15,14 +15,14 @@
  */
 
 package pink.cozydev.lucille
-import cats.parse.Parser.Error
 import Query._
-import Parser._
 
 // Similar to the SingleSimpleQuerySuite but with a focus on queries with punctuation
 class PunctuationSuite extends munit.FunSuite {
 
-  def assertSingleQ(r: Either[Error, MultiQuery], expected: Query)(implicit
+  val parseQ = QueryParser.parse
+
+  def assertSingleQ(r: Either[String, MultiQuery], expected: Query)(implicit
       loc: munit.Location
   ) =
     assertEquals(r, Right(MultiQuery(expected)))

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -22,34 +22,29 @@ class PunctuationSuite extends munit.FunSuite {
 
   val parseQ = QueryParser.parse(_)
 
-  def assertSingleQ(r: Either[String, MultiQuery], expected: Query)(implicit
-      loc: munit.Location
-  ) =
-    assertEquals(r, Right(MultiQuery(expected)))
-
   test("parse single term with period") {
     val r = parseQ("typelevel.com")
-    assertSingleQ(r, Term("typelevel.com"))
+    assertEquals(r, Right(Term("typelevel.com")))
   }
 
   test("parse single term with slash") {
     val r = parseQ("typelevel.com/cats")
-    assertSingleQ(r, Term("typelevel.com/cats"))
+    assertEquals(r, Right(Term("typelevel.com/cats")))
   }
 
   test("parse single term with dash") {
     val r = parseQ("cats-effect")
-    assertSingleQ(r, Term("cats-effect"))
+    assertEquals(r, Right(Term("cats-effect")))
   }
 
   test("parse single term with '@'") {
     val r = parseQ("first.last@email.com")
-    assertSingleQ(r, Term("first.last@email.com"))
+    assertEquals(r, Right(Term("first.last@email.com")))
   }
 
   test("parse fieldQ with phraseQ with dash") {
     val r = parseQ("name:\"cats-effect\"")
-    assertSingleQ(r, Field("name", Phrase("cats-effect")))
+    assertEquals(r, Right(Field("name", Phrase("cats-effect"))))
   }
 
 }

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -40,15 +40,15 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
   }
 
   test("prints Not query") {
-    val q = Not(Group(NonEmptyList.of(Term("hello"), Term("hi"))))
+    val q = Not(Group(Or(Term("hello"), Term("hi"))))
     val str = QueryPrinter.print(q)
-    assertEquals(str, "NOT (hello hi)")
+    assertEquals(str, "NOT (hello OR hi)")
   }
 
   test("prints Group query") {
-    val q = Group(NonEmptyList.of(Term("hello"), Term("hi")))
+    val q = Group(Or(Term("hello"), Term("hi")))
     val str = QueryPrinter.print(q)
-    assertEquals(str, "(hello hi)")
+    assertEquals(str, "(hello OR hi)")
   }
 
   test("prints UnaryMinus query") {
@@ -106,21 +106,21 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
   }
 
   test("prints Boost query with group") {
-    val q = Boost(Group(Term("hello"), Field("fieldB", Term("d"))), 3.1f)
+    val q = Boost(Group(Or(Term("hello"), Field("fieldB", Term("d")))), 3.1f)
     val str = QueryPrinter.print(q)
-    assertEquals(str, "(hello fieldB:d)^3.10")
+    assertEquals(str, "(hello OR fieldB:d)^3.10")
   }
 
   test("prints Boost query with other queries included") {
     val q = Or(
       Boost(
-        Or(Field("fieldA", Group(NonEmptyList.of(Or(Term("a"), Term("b")), Not(Term("c")))))),
+        Or(Field("fieldA", Group(Or(Or(Term("a"), Term("b")), Not(Term("c")))))),
         2.50f,
       ),
       Field("fieldB", Term("d")),
     )
     val str = QueryPrinter.print(q)
-    assertEquals(str, "(fieldA:(a OR b NOT c))^2.50 OR fieldB:d")
+    assertEquals(str, "(fieldA:(a OR b OR NOT c))^2.50 OR fieldB:d")
   }
 
   test("prints Field query") {

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -21,12 +21,6 @@ import cats.data.NonEmptyList
 
 class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
 
-  test("prints MultiQuery query") {
-    val q = MultiQuery(NonEmptyList.of(Term("hello"), Term("hi")))
-    val str = QueryPrinter.print(q)
-    assertEquals(str, "hello hi")
-  }
-
   test("prints OR query") {
     val q = Or(NonEmptyList.of(Term("hello"), Term("hi")))
     val str = QueryPrinter.print(q)

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -28,28 +28,28 @@ class QuerySuite extends munit.FunSuite {
       case _ => q
     }
 
-  test("MultiQuery.mapLastTerm maps last Term in last Query (OR)") {
-    val mq = MultiQuery(Or(Term("cats"), Term("dogs")))
-    val expected = MultiQuery(Or(Term("cats"), Or(Term("dogs"), Prefix("dogs"))))
-    assertEquals(mq.mapLastTerm(expandQ), expected)
+  test("Or#mapLastTerm maps last Term in last Query (OR)") {
+    val q = Or(Term("cats"), Term("dogs"))
+    val expected = Or(Term("cats"), Or(Term("dogs"), Prefix("dogs")))
+    assertEquals(q.mapLastTerm(expandQ), expected)
   }
 
-  test("MultiQuery.mapLastTerm maps last Term in last Query (AND)") {
-    val mq = MultiQuery(And(Term("cats"), Term("dogs")))
-    val expected = MultiQuery(And(Term("cats"), Or(Term("dogs"), Prefix("dogs"))))
-    assertEquals(mq.mapLastTerm(expandQ), expected)
+  test("And#mapLastTerm maps last Term in last Query (AND)") {
+    val q = And(Term("cats"), Term("dogs"))
+    val expected = And(Term("cats"), Or(Term("dogs"), Prefix("dogs")))
+    assertEquals(q.mapLastTerm(expandQ), expected)
   }
 
-  test("MultiQuery.mapLastTerm maps last Term in last Query (NOT)") {
-    val mq = MultiQuery(Term("cats"), Not(Term("dogs")))
-    val expected = MultiQuery(Term("cats"), Not(Or(Term("dogs"), Prefix("dogs"))))
-    assertEquals(mq.mapLastTerm(expandQ), expected)
+  test("Or#mapLastTerm maps last Term in last Query (NOT)") {
+    val q = Or(Term("cats"), Not(Term("dogs")))
+    val expected = Or(Term("cats"), Not(Or(Term("dogs"), Prefix("dogs"))))
+    assertEquals(q.mapLastTerm(expandQ), expected)
   }
 
-  test("MultiQuery.mapLastTerm maps last Term in last Query (OR + NOT)") {
-    val mq = MultiQuery(Or(Term("cats"), Not(Term("dogs"))))
-    val expected = MultiQuery(Or(Term("cats"), Not(Or(Term("dogs"), Prefix("dogs")))))
-    assertEquals(mq.mapLastTerm(expandQ), expected)
+  test("And#mapLastTerm maps last Term in last Query (NOT)") {
+    val q = And(Term("cats"), Not(Term("dogs")))
+    val expected = And(Term("cats"), Not(Or(Term("dogs"), Prefix("dogs"))))
+    assertEquals(q.mapLastTerm(expandQ), expected)
   }
 
   test("MultiQuery.mapLastTerm does nothing for ending minimum-should-match query") {

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -19,6 +19,9 @@ package pink.cozydev.lucille
 import pink.cozydev.lucille.Query._
 
 class QuerySuite extends munit.FunSuite {
+
+  val parseQ = QueryParser.parse
+
   def expandQ(q: Query): Query =
     q match {
       case Query.Term(t) => Query.Or(Query.Term(t), Query.Prefix(t))
@@ -51,19 +54,19 @@ class QuerySuite extends munit.FunSuite {
 
   test("MultiQuery.mapLastTerm does nothing for ending minimum-should-match query") {
     val qs = "(apple banana orange)@2"
-    val mq = Parser.parseQ(qs)
+    val mq = parseQ(qs)
     assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
   }
 
   test("MultiQuery.mapLastTerm does nothing for ending range query") {
     val qs = "name:[cats TO fs2]"
-    val mq = Parser.parseQ(qs)
+    val mq = parseQ(qs)
     assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
   }
 
   test("MultiQuery.mapLastTerm does nothing for ending group query") {
     val qs = "cats AND (dogs OR fish)"
-    val mq = Parser.parseQ(qs)
+    val mq = parseQ(qs)
     assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
   }
 }

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -20,7 +20,7 @@ import pink.cozydev.lucille.Query._
 
 class QuerySuite extends munit.FunSuite {
 
-  val parseQ = QueryParser.parse
+  val parseQ = QueryParser.parse(_)
 
   def expandQ(q: Query): Query =
     q match {

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -52,21 +52,21 @@ class QuerySuite extends munit.FunSuite {
     assertEquals(q.mapLastTerm(expandQ), expected)
   }
 
-  test("MultiQuery.mapLastTerm does nothing for ending minimum-should-match query") {
+  test("Query.mapLastTerm does nothing for ending minimum-should-match query") {
     val qs = "(apple banana orange)@2"
-    val mq = parseQ(qs)
-    assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
+    val q = parseQ(qs)
+    assertEquals(q.map(_.mapLastTerm(expandQ)), q)
   }
 
-  test("MultiQuery.mapLastTerm does nothing for ending range query") {
+  test("Query.mapLastTerm does nothing for ending range query") {
     val qs = "name:[cats TO fs2]"
-    val mq = parseQ(qs)
-    assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
+    val q = parseQ(qs)
+    assertEquals(q.map(_.mapLastTerm(expandQ)), q)
   }
 
-  test("MultiQuery.mapLastTerm does nothing for ending group query") {
+  test("Query.mapLastTerm does nothing for ending group query") {
     val qs = "cats AND (dogs OR fish)"
-    val mq = parseQ(qs)
-    assertEquals(mq.map(_.mapLastTerm(expandQ)), mq)
+    val q = parseQ(qs)
+    assertEquals(q.map(_.mapLastTerm(expandQ)), q)
   }
 }

--- a/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
@@ -44,7 +44,7 @@ class RegexSuite extends munit.FunSuite {
 
   test("parse multipe regex in a group") {
     val r = parseQ("(/jump.*/ /.ouse/)")
-    assertSingleQ(r, Group(TermRegex("jump.*"), TermRegex(".ouse")))
+    assertSingleQ(r, Group(Or(TermRegex("jump.*"), TermRegex(".ouse"))))
   }
 
   test("parse regex with escaped slash") {

--- a/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
@@ -15,21 +15,15 @@
  */
 
 package pink.cozydev.lucille
-import cats.data.NonEmptyList
 import Query._
 
 class RegexSuite extends munit.FunSuite {
 
   val parseQ = QueryParser.parse(_)
 
-  def assertSingleQ(r: Either[String, MultiQuery], expected: Query)(implicit
-      loc: munit.Location
-  ) =
-    assertEquals(r, Right(MultiQuery(NonEmptyList.one(expected))))
-
   test("parse single regex with wildcard star") {
     val r = parseQ("/jump.*/")
-    assertSingleQ(r, TermRegex("jump.*"))
+    assertEquals(r, Right(TermRegex("jump.*")))
   }
 
   test("does not parse without ending slash") {
@@ -39,17 +33,17 @@ class RegexSuite extends munit.FunSuite {
 
   test("parse regex with repeat min-max") {
     val r = parseQ("/hi{1,5}/")
-    assertSingleQ(r, TermRegex("hi{1,5}"))
+    assertEquals(r, Right(TermRegex("hi{1,5}")))
   }
 
   test("parse multipe regex in a group") {
     val r = parseQ("(/jump.*/ /.ouse/)")
-    assertSingleQ(r, Group(Or(TermRegex("jump.*"), TermRegex(".ouse"))))
+    assertEquals(r, Right(Group(Or(TermRegex("jump.*"), TermRegex(".ouse")))))
   }
 
   test("parse regex with escaped slash") {
     val r = parseQ("""/home\/.*/""")
-    assertSingleQ(r, TermRegex("""home\/.*"""))
+    assertEquals(r, Right(TermRegex("""home\/.*""")))
   }
 
 }

--- a/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
@@ -16,13 +16,13 @@
 
 package pink.cozydev.lucille
 import cats.data.NonEmptyList
-import cats.parse.Parser.Error
 import Query._
-import Parser._
 
 class RegexSuite extends munit.FunSuite {
 
-  def assertSingleQ(r: Either[Error, MultiQuery], expected: Query)(implicit
+  val parseQ = QueryParser.parse
+
+  def assertSingleQ(r: Either[String, MultiQuery], expected: Query)(implicit
       loc: munit.Location
   ) =
     assertEquals(r, Right(MultiQuery(NonEmptyList.one(expected))))

--- a/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/RegexSuite.scala
@@ -20,7 +20,7 @@ import Query._
 
 class RegexSuite extends munit.FunSuite {
 
-  val parseQ = QueryParser.parse
+  val parseQ = QueryParser.parse(_)
 
   def assertSingleQ(r: Either[String, MultiQuery], expected: Query)(implicit
       loc: munit.Location

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -39,7 +39,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Term("test"), Term("equipment"))
+        MultiQuery(Or(Term("test"), Term("equipment")))
       ),
     )
   }
@@ -157,7 +157,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       r,
       Right(
         MultiQuery(
-          Field("title", Group(Term("pass"), Term("fail"), Term("skip")))
+          Field("title", Group(Or(Term("pass"), Term("fail"), Term("skip"))))
         )
       ),
     )
@@ -172,8 +172,10 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
           Field(
             "title",
             Group(
-              UnaryPlus(Term("test")),
-              UnaryPlus(Phrase("result unknown")),
+              Or(
+                UnaryPlus(Term("test")),
+                UnaryPlus(Phrase("result unknown")),
+              )
             ),
           )
         )
@@ -220,7 +222,8 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
       Right(
         MultiQuery(
           Or(
-            Field("field", Boost(Group(Or(Term("a"), Term("b")), Not(Term("c"))), 2.5f)),
+            // TODO I don't like the group or the nested Or's
+            Field("field", Boost(Group(Or(Or(Term("a"), Term("b")), Not(Term("c")))), 2.5f)),
             Field("field", Term("d")),
           )
         )

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -22,7 +22,7 @@ import Query._
 // https://lucene.apache.org/core/9_4_1/queryparser/org/apache/lucene/queryparser/flexible/standard/StandardQueryParser.html
 class StandardQueryParserDocsSuite extends munit.FunSuite {
 
-  val parseQ = QueryParser.parse
+  val parseQ = QueryParser.parse(_)
 
   test("test") {
     val r = parseQ("test")

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -29,7 +29,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Term("test"))
+        Term("test")
       ),
     )
   }
@@ -39,7 +39,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Or(Term("test"), Term("equipment")))
+        Or(Term("test"), Term("equipment"))
       ),
     )
   }
@@ -49,7 +49,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Proximity("test failure", 4))
+        Proximity("test failure", 4)
       ),
     )
   }
@@ -59,7 +59,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Prefix("tes"))
+        Prefix("tes")
       ),
     )
   }
@@ -69,7 +69,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(TermRegex(".est(s|ing)"))
+        TermRegex(".est(s|ing)")
       ),
     )
   }
@@ -79,7 +79,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Fuzzy("nest", Some(4)))
+        Fuzzy("nest", Some(4))
       ),
     )
   }
@@ -89,7 +89,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(Field("title", Term("test")))
+        Field("title", Term("test"))
       ),
     )
   }
@@ -99,9 +99,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Field("title", Group(Or(Term("die"), Term("hard"))))
-        )
+        Field("title", Group(Or(Term("die"), Term("hard"))))
       ),
     )
   }
@@ -111,7 +109,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(And(Term("test"), Term("results")))
+        And(Term("test"), Term("results"))
       ),
     )
   }
@@ -121,11 +119,9 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          And(
-            Field("title", Term("test")),
-            Not(Field("title", Term("complete"))),
-          )
+        And(
+          Field("title", Term("test")),
+          Not(Field("title", Term("complete"))),
         )
       ),
     )
@@ -136,16 +132,14 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          And(
-            Field("title", Term("test")),
-            Group(
-              Or(
-                Prefix("pass"),
-                Prefix("fail"),
-              )
-            ),
-          )
+        And(
+          Field("title", Term("test")),
+          Group(
+            Or(
+              Prefix("pass"),
+              Prefix("fail"),
+            )
+          ),
         )
       ),
     )
@@ -156,9 +150,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Field("title", Group(Or(Term("pass"), Term("fail"), Term("skip"))))
-        )
+        Field("title", Group(Or(Term("pass"), Term("fail"), Term("skip"))))
       ),
     )
   }
@@ -168,16 +160,14 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Field(
-            "title",
-            Group(
-              Or(
-                UnaryPlus(Term("test")),
-                UnaryPlus(Phrase("result unknown")),
-              )
-            ),
-          )
+        Field(
+          "title",
+          Group(
+            Or(
+              UnaryPlus(Term("test")),
+              UnaryPlus(Phrase("result unknown")),
+            )
+          ),
         )
       ),
     )
@@ -187,7 +177,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("name:[Jones TO Smith]")
     assertEquals(
       r,
-      Right(MultiQuery(Field("name", TermRange(Some("Jones"), Some("Smith"), true, true)))),
+      Right(Field("name", TermRange(Some("Jones"), Some("Smith"), true, true))),
     )
   }
 
@@ -195,7 +185,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("score:{2.5 TO 7.3}")
     assertEquals(
       r,
-      Right(MultiQuery(Field("score", TermRange(Some("2.5"), Some("7.3"), false, false)))),
+      Right(Field("score", TermRange(Some("2.5"), Some("7.3"), false, false))),
     )
   }
 
@@ -203,7 +193,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("score:{2.5 TO *]")
     assertEquals(
       r,
-      Right(MultiQuery(Field("score", TermRange(Some("2.5"), None, false, true)))),
+      Right(Field("score", TermRange(Some("2.5"), None, false, true))),
     )
   }
 
@@ -211,7 +201,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     val r = parseQ("jones^2 OR smith^0.5")
     assertEquals(
       r,
-      Right(MultiQuery(Or(Boost(Term("jones"), 2f), Boost(Term("smith"), 0.5f)))),
+      Right(Or(Boost(Term("jones"), 2f), Boost(Term("smith"), 0.5f))),
     )
   }
 
@@ -220,12 +210,10 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          Or(
-            // TODO I don't like the group or the nested Or's
-            Field("field", Boost(Group(Or(Or(Term("a"), Term("b")), Not(Term("c")))), 2.5f)),
-            Field("field", Term("d")),
-          )
+        Or(
+          // TODO I don't like the group or the nested Or's
+          Field("field", Boost(Group(Or(Or(Term("a"), Term("b")), Not(Term("c")))), 2.5f)),
+          Field("field", Term("d")),
         )
       ),
     )
@@ -241,9 +229,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          MinimumMatch(NonEmptyList.of(Term("blue"), Term("crab"), Term("fish")), 2)
-        )
+        MinimumMatch(NonEmptyList.of(Term("blue"), Term("crab"), Term("fish")), 2)
       ),
     )
   }
@@ -253,17 +239,15 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     assertEquals(
       r,
       Right(
-        MultiQuery(
-          MinimumMatch(
-            NonEmptyList.of(
-              Group(
-                Or(Term("yellow"), Term("blue"))
-              ),
-              Term("crab"),
-              Term("fish"),
+        MinimumMatch(
+          NonEmptyList.of(
+            Group(
+              Or(Term("yellow"), Term("blue"))
             ),
-            2,
-          )
+            Term("crab"),
+            Term("fish"),
+          ),
+          2,
         )
       ),
     )

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -17,11 +17,12 @@
 package pink.cozydev.lucille
 import cats.data.NonEmptyList
 import Query._
-import Parser._
 
 // Cases taken from the Lucene StandardQueryParser docs
 // https://lucene.apache.org/core/9_4_1/queryparser/org/apache/lucene/queryparser/flexible/standard/StandardQueryParser.html
 class StandardQueryParserDocsSuite extends munit.FunSuite {
+
+  val parseQ = QueryParser.parse
 
   test("test") {
     val r = parseQ("test")

--- a/core/src/test/scala/pink/cozydev/lucille/internal/OpSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/internal/OpSuite.scala
@@ -24,7 +24,7 @@ class AssociateOpsSuite extends munit.FunSuite {
   test("associates ORs") {
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((OR, Term("dog")))
-    val result = associateOps(leftQs, opQs)
+    val result = associateOps(leftQs, opQs, defaultBooleanOR = true)
     val expected = NonEmptyList.of(Term("the"), Or(Term("cat"), Term("dog")))
     assertEquals(result, expected)
   }
@@ -32,7 +32,7 @@ class AssociateOpsSuite extends munit.FunSuite {
   test("associates ANDs") {
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((AND, Term("dog")))
-    val result = associateOps(leftQs, opQs)
+    val result = associateOps(leftQs, opQs, defaultBooleanOR = true)
     val expected = NonEmptyList.of(Term("the"), And(Term("cat"), Term("dog")))
     assertEquals(result, expected)
   }
@@ -40,7 +40,7 @@ class AssociateOpsSuite extends munit.FunSuite {
   test("associates multiple ORs") {
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((OR, Term("dog")), (OR, Term("fish")))
-    val result = associateOps(leftQs, opQs)
+    val result = associateOps(leftQs, opQs, defaultBooleanOR = true)
     val expected =
       NonEmptyList.of(Term("the"), Or(Term("cat"), Term("dog"), Term("fish")))
     assertEquals(result, expected)
@@ -49,7 +49,7 @@ class AssociateOpsSuite extends munit.FunSuite {
   test("associates multiple ANDs") {
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((AND, Term("dog")), (AND, Term("fish")))
-    val result = associateOps(leftQs, opQs)
+    val result = associateOps(leftQs, opQs, defaultBooleanOR = true)
     val expected =
       NonEmptyList.of(
         Term("the"),
@@ -63,7 +63,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     // default:the default:cat +default:ocean +default:fish
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((OR, Term("ocean")), (AND, Term("fish")))
-    val result = associateOps(leftQs, opQs)
+    val result = associateOps(leftQs, opQs, defaultBooleanOR = true)
     val expected =
       NonEmptyList.of(
         Term("the"),
@@ -78,7 +78,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     // default:the +default:cat +default:ocean default:fish
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((AND, Term("ocean")), (OR, Term("fish")))
-    val result = associateOps(leftQs, opQs)
+    val result = associateOps(leftQs, opQs, defaultBooleanOR = true)
     val expected =
       NonEmptyList.of(
         Term("the"),
@@ -93,7 +93,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     // default:the default:cat default:ocean +default:ocean2 +default:fish
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((OR, Term("ocean")), (OR, Term("ocean2")), (AND, Term("fish")))
-    val result = associateOps(leftQs, opQs)
+    val result = associateOps(leftQs, opQs, defaultBooleanOR = true)
     val expected =
       NonEmptyList.of(
         Term("the"),
@@ -109,7 +109,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     // default:the +default:cat +default:ocean +default:ocean2 default:fish
     val leftQs = NonEmptyList.of(Term("the"), Term("cat"))
     val opQs = List((AND, Term("ocean")), (AND, Term("ocean2")), (OR, Term("fish")))
-    val result = associateOps(leftQs, opQs)
+    val result = associateOps(leftQs, opQs, defaultBooleanOR = true)
     val expected =
       NonEmptyList.of(
         Term("the"),

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ def expandQ(q: Query): Query =
   }
 ```
 
-We can now use `expandQ` along with `mapLastTerm` to rewrite the last term of a `MultiQuery` into our
+We can now use `expandQ` along with `mapLastTerm` to rewrite the last term of a `Query` into our
 expanded term + prefix:
 
 ```scala mdoc

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,12 +21,24 @@ libraryDependencies += "pink.cozydev" %%% "lucille" % "@VERSION@"
 
 ### Parsing
 
-Lucille offers a `parse` function to parse a whole string into a Lucille `MultiQuery` structure:
+Lucille offers a `parse` function to parse a whole string into a Lucille `Query` structure:
 
 ```scala mdoc
 import pink.cozydev.lucille.QueryParser
 
-QueryParser.parse("cats OR dogs")
+QueryParser.default.parse("cats OR dogs")
+```
+
+The default `QueryParser` automatically inserts an `OR` operation inbetween consecutive terms.
+
+```scala mdoc
+QueryParser.withDefaultOperatorOR.parse("cats dogs")
+```
+
+This can be changed to an `AND` operation via `withDefaultOperatorAND`:
+
+```scala mdoc
+QueryParser.withDefaultOperatorAND.parse("cats dogs")
 ```
 
 ### Printing


### PR DESCRIPTION
This PR tackles a handful of issues:
(but hopefully the commits are still pretty isolated and clean 😬 )
  - [Support configuring default boolean (OR / AND)](https://github.com/cozydev-pink/lucille/issues/124)
    - this is accomplished by making `QueryParser` a class with a `defaultBooleanOR` param
  - Changing `Group` to take only a single `Query` instead of a list
    - This addresses Problem 2 from https://github.com/cozydev-pink/lucille/issues/142
    - the idea being that we should have a group of queries without knowing the boolean operator that connects them
    - Note: A `MinimumMatch` query is an exception to this, it contains a list of queries that truly are not linked by either an `AND` or `OR`
  - Removes `MultiQuery`
    - This addresses Problem 3 from https://github.com/cozydev-pink/lucille/issues/142
    - Also part of the effort to not have lists of queries with unknown boolean operators

There remain a handful of TODO comments in the tests.
This are mostly around needlessly nested queries. But I think resolving these might make this PR even larger...