### PR TITLE
Add `WildCard` queries

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -218,6 +218,15 @@ object Query {
       Field(field, q.mapLastTerm(f))
   }
 
+  sealed trait WildCardOp extends Product with Serializable
+  object WildCardOp {
+    case object SingleChar extends WildCardOp
+    case object ManyChar extends WildCardOp
+    case class Str(str: String) extends WildCardOp
+  }
+
+  final case class WildCard(ops: NonEmptyList[WildCardOp]) extends TermQuery
+
   private def rewriteLastTerm(
       qs: NonEmptyList[Query],
       f: Query.Term => Query,

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -107,7 +107,19 @@ object QueryPrinter {
           sb.append(" TO ")
           sb.append(q.upper.getOrElse("*"))
           if (q.upperInc) sb.append('}') else sb.append(']')
+        case q: WildCard =>
+          printWildCard(q)
       }
+
+    def printWildCard(q: WildCard): Unit = {
+      def printOp(op: WildCardOp): Unit =
+        op match {
+          case WildCardOp.SingleChar => sb.append('?')
+          case WildCardOp.ManyChar => sb.append('*')
+          case WildCardOp.Str(str) => sb.append(str)
+        }
+      q.ops.iterator.foreach(printOp)
+    }
 
     def printEachNel(nel: NonEmptyList[Query], sep: String): Unit = {
       printQ(nel.head)

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -122,7 +122,34 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
     val str = QueryPrinter.print(q)
     assertEquals(str, "msg:(hello hi)@2")
   }
+}
 
+class QueryPrinterWildCardSuite extends munit.FunSuite {
+
+  test("prints Wildcard query leading many") {
+    val q = WildCard(NonEmptyList.of(WildCardOp.ManyChar, WildCardOp.Str("tail")))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "*tail")
+  }
+
+  test("prints Wildcard query leading single") {
+    val q = WildCard(NonEmptyList.of(WildCardOp.SingleChar, WildCardOp.Str("tail")))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "?tail")
+  }
+
+  test("prints Wildcard mix ops") {
+    val q = WildCard(
+      NonEmptyList.of(
+        WildCardOp.Str("head"),
+        WildCardOp.SingleChar,
+        WildCardOp.Str("tail"),
+        WildCardOp.ManyChar,
+      )
+    )
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "head?tail*")
+  }
 }
 
 class QueryPrinterSimpleQueryTermSuite extends munit.FunSuite {

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -150,6 +150,12 @@ class QueryPrinterWildCardSuite extends munit.FunSuite {
     val str = QueryPrinter.print(q)
     assertEquals(str, "head?tail*")
   }
+
+  test("prints Wildcard query simple string as term query") {
+    val q = WildCard(NonEmptyList.of(WildCardOp.Str("simple")))
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "simple")
+  }
 }
 
 class QueryPrinterSimpleQueryTermSuite extends munit.FunSuite {

--- a/core/src/test/scala/pink/cozydev/lucille/WildCardParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/WildCardParserSuite.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.lucille
+import Query._
+import WildCardOp._
+import cats.data.NonEmptyList
+
+class WildCardParserSuite extends munit.FunSuite {
+
+  // We already have a `Prefix` query
+  // do we make this a special case of the larger `Wildcard` query?
+  val parseQ = QueryParser.withDefaultOperatorOR.parse(_)
+
+  test("trailing single char") {
+    val r = parseQ("cat?")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(Str("cat"), SingleChar))))
+  }
+
+  test("trailing many char") {
+    val r = parseQ("cat*")
+    assertEquals(r, Right(Prefix("cat")))
+  }
+
+  test("leading single char") {
+    val r = parseQ("?cat")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(SingleChar, Str("cat")))))
+  }
+
+  test("leading many char") {
+    val r = parseQ("*cat")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(ManyChar, Str("cat")))))
+  }
+
+  test("middle many char") {
+    val r = parseQ("cat*tail")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(Str("cat"), ManyChar, Str("tail")))))
+  }
+
+  test("middle single char") {
+    val r = parseQ("cat?tail")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(Str("cat"), SingleChar, Str("tail")))))
+  }
+
+  test("trailing single char grouped") {
+    val r = parseQ("(cat?)")
+    assertEquals(r, Right(Group(WildCard(NonEmptyList.of(Str("cat"), SingleChar)))))
+  }
+
+  test("trailing many char grouped") {
+    val r = parseQ("(cat*)")
+    assertEquals(r, Right(Group(Prefix("cat"))))
+  }
+
+  test("leading single char grouped") {
+    val r = parseQ("(?cat)")
+    assertEquals(r, Right(Group(WildCard(NonEmptyList.of(SingleChar, Str("cat"))))))
+  }
+
+  test("leading many char grouped") {
+    val r = parseQ("(*cat)")
+    assertEquals(r, Right(Group(WildCard(NonEmptyList.of(ManyChar, Str("cat"))))))
+  }
+
+  test("middle many char grouped") {
+    val r = parseQ("(cat*tail)")
+    assertEquals(r, Right(Group(WildCard(NonEmptyList.of(Str("cat"), ManyChar, Str("tail"))))))
+  }
+
+  test("middle single char grouped") {
+    val r = parseQ("(cat?tail)")
+    assertEquals(r, Right(Group(WildCard(NonEmptyList.of(Str("cat"), SingleChar, Str("tail"))))))
+  }
+
+  test("trailing single char boosted") {
+    val r = parseQ("cat?^2")
+    assertEquals(r, Right(Boost(WildCard(NonEmptyList.of(Str("cat"), SingleChar)), 2.0f)))
+  }
+
+  test("trailing many char boosted") {
+    val r = parseQ("cat*^2")
+    assertEquals(r, Right(Boost(Prefix("cat"), 2.0f)))
+  }
+
+  test("leading single char boosted") {
+    val r = parseQ("?cat^2")
+    assertEquals(r, Right(Boost(WildCard(NonEmptyList.of(SingleChar, Str("cat"))), 2.0f)))
+  }
+
+  test("leading many char boosted") {
+    val r = parseQ("*cat^2")
+    assertEquals(r, Right(Boost(WildCard(NonEmptyList.of(ManyChar, Str("cat"))), 2.0f)))
+  }
+
+  test("middle many char boosted") {
+    val r = parseQ("cat*tail^2")
+    assertEquals(
+      r,
+      Right(Boost(WildCard(NonEmptyList.of(Str("cat"), ManyChar, Str("tail"))), 2.0f)),
+    )
+  }
+
+  test("middle single char boosted") {
+    val r = parseQ("cat?tail^2")
+    assertEquals(
+      r,
+      Right(Boost(WildCard(NonEmptyList.of(Str("cat"), SingleChar, Str("tail"))), 2.0f)),
+    )
+  }
+
+}

--- a/core/src/test/scala/pink/cozydev/lucille/WildCardParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/WildCardParserSuite.scala
@@ -45,6 +45,26 @@ class WildCardParserSuite extends munit.FunSuite {
     assertEquals(r, Right(WildCard(NonEmptyList.of(ManyChar, Str("cat")))))
   }
 
+  test("leading single char, trailing single char") {
+    val r = parseQ("?cat?")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(SingleChar, Str("cat"), SingleChar))))
+  }
+
+  test("leading single char, trailing many char") {
+    val r = parseQ("?cat*")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(SingleChar, Str("cat"), ManyChar))))
+  }
+
+  test("leading many char, trailing single char") {
+    val r = parseQ("*cat?")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(ManyChar, Str("cat"), SingleChar))))
+  }
+
+  test("leading many char, trailing many char") {
+    val r = parseQ("*cat*")
+    assertEquals(r, Right(WildCard(NonEmptyList.of(ManyChar, Str("cat"), ManyChar))))
+  }
+
   test("middle many char") {
     val r = parseQ("cat*tail")
     assertEquals(r, Right(WildCard(NonEmptyList.of(Str("cat"), ManyChar, Str("tail")))))


### PR DESCRIPTION
This PR adds support for wildcard queries.

Resolves https://github.com/cozydev-pink/lucille/issues/145

Previously we could only parse queries like `cat*` as `Prefix` nodes.
Now we can parse the following into a new `Wildcard` node.

- `cat?`
- `?cat`
- `cat*tail`
- `cat?tail`

And so on.

