### PR TITLE
Support escaping characters

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -191,24 +191,25 @@ private object Parser {
   }
 
   private val baseRange = (0x20.toChar to 0x10ffff.toChar).toSet
+  private val quotes = Set('"', '“', '”')
   val luceneSpecial =
     Set('+', '-', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '\\', '/')
-  private val special = Set('“', '”', ' ') ++ luceneSpecial
+  private val special = luceneSpecial ++ quotes + ' '
+  val escapedTokensPhraseSet = quotes + '\\'
   private val escapedTokens = P.char('\\') *> P.charIn(special)
-  private val allowed: P[Char] =
-    // From cats.parse.strings.Json nonEscaped handling
-    P.charIn(baseRange -- special)
+  // From cats.parse.strings.Json nonEscaped handling
+  private val allowed: P[Char] = P.charIn(baseRange -- special)
   val reserved = Set("OR", "||", "AND", "&&", "NOT", "+", "-", "/")
 
   val queryEnd = (wsp | P.end | P.char(')')).peek
 
-  // We use repAs[String] to escape the slashes
+  // We use repAs[String] to avoid capturing the literal escape slash characters
   val term: P[String] =
     P.not(P.stringIn(reserved)).with1 *> allowed.orElse(escapedTokens).repAs[String]
 
-  private val quotes = Set('"', '“', '”')
-
-  private val phraseTerm = P.charIn(baseRange -- quotes).repAs[String]
+  private val phraseEscapeToken = P.char('\\') *> P.charIn(escapedTokensPhraseSet)
+  private val phraseTerm =
+    P.charIn(baseRange -- escapedTokensPhraseSet).orElse(phraseEscapeToken).repAs[String]
 
   val phrase: P[String] = phraseTerm.surroundedBy(P.charIn(quotes))
 

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -18,6 +18,7 @@ package pink.cozydev.lucille
 
 import pink.cozydev.lucille.Query._
 import cats.data.NonEmptyList
+import pink.cozydev.lucille.Parser.luceneSpecial
 
 object QueryPrinter {
 
@@ -83,7 +84,7 @@ object QueryPrinter {
 
     def strTermQuery(q: TermQuery): Unit =
       q match {
-        case q: Term => sb.append(q.str)
+        case q: Term => escapeStr(q.str)
         case q: Phrase =>
           sb.append('"')
           sb.append(q.str)
@@ -128,6 +129,12 @@ object QueryPrinter {
         printQ(q)
       }
     }
+
+    def escapeStr(str: String): Unit =
+      str.foreach { c =>
+        if (luceneSpecial.contains(c)) sb.append('\\')
+        sb.append(c)
+      }
 
     printQ(query)
     sb.result()

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -19,6 +19,7 @@ package pink.cozydev.lucille
 import pink.cozydev.lucille.Query._
 import cats.data.NonEmptyList
 import pink.cozydev.lucille.Parser.luceneSpecial
+import pink.cozydev.lucille.Parser.escapedTokensPhraseSet
 
 object QueryPrinter {
 
@@ -87,7 +88,7 @@ object QueryPrinter {
         case q: Term => escapeStr(q.str)
         case q: Phrase =>
           sb.append('"')
-          sb.append(q.str)
+          escapePhrase(q.str)
           sb.append('"')
         case q: Prefix =>
           sb.append(q.str)
@@ -133,6 +134,12 @@ object QueryPrinter {
     def escapeStr(str: String): Unit =
       str.foreach { c =>
         if (luceneSpecial.contains(c)) sb.append('\\')
+        sb.append(c)
+      }
+
+    def escapePhrase(str: String): Unit =
+      str.foreach { c =>
+        if (escapedTokensPhraseSet.contains(c)) sb.append('\\')
         sb.append(c)
       }
 

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -155,6 +155,16 @@ class SingleSimpleQuerySuite extends munit.FunSuite {
     assert(r.isLeft)
   }
 
+  test("parse escaped characters simple") {
+    val r = parseQ("cat\\:dog")
+    assertSingleTerm(r, Term("cat:dog"))
+  }
+
+  test("parse escaped characters complex") {
+    val r = parseQ("\\(1\\+1\\)\\:2")
+    assertSingleTerm(r, Term("(1+1):2"))
+  }
+
 }
 
 class MultiSimpleQuerySuite extends munit.FunSuite {

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -28,12 +28,12 @@ class PunctuationSuite extends munit.FunSuite {
   }
 
   test("parse single term with slash") {
-    val r = parseQ("typelevel.com/cats")
+    val r = parseQ("typelevel.com\\/cats")
     assertEquals(r, Right(Term("typelevel.com/cats")))
   }
 
   test("parse single term with dash") {
-    val r = parseQ("cats-effect")
+    val r = parseQ("cats\\-effect")
     assertEquals(r, Right(Term("cats-effect")))
   }
 

--- a/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/PunctuationSuite.scala
@@ -47,4 +47,14 @@ class PunctuationSuite extends munit.FunSuite {
     assertEquals(r, Right(Field("name", Phrase("cats-effect"))))
   }
 
+  test("parse phrase query with quotes") {
+    val r = parseQ("\"the cat said \\\"meow\\\" loudly\"")
+    assertEquals(r, Right(Phrase("""the cat said "meow" loudly""")))
+  }
+
+  test("parse phrase query with backslash") {
+    val r = parseQ("\"This is a blackslash: \\\\, wow!\"")
+    assertEquals(r, Right(Phrase("""This is a blackslash: \, wow!""")))
+  }
+
 }

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -227,3 +227,29 @@ class QueryPrinterSimpleQueryTermSuite extends munit.FunSuite {
   }
 
 }
+
+class QueryPrinterEscapedTermSuite extends munit.FunSuite {
+  def assertRoundTripParsePrint(s: String)(implicit loc: munit.Location) = {
+    val parseQ = QueryParser.parse(s)
+    val printQ = parseQ.map(QueryPrinter.print(_))
+    assertEquals(printQ, Right(s), s"parseQ: $parseQ, printQ: $printQ")
+  }
+
+  test("prints escaped term") {
+    val q = Term("cat:dog")
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "cat\\:dog")
+  }
+
+  test("prints escaped another term") {
+    val q = Term("(1+1):2")
+    val str = QueryPrinter.print(q)
+    assertEquals(str, "\\(1\\+1\\)\\:2")
+  }
+
+  test("round trips Phrases") {
+    assertRoundTripParsePrint("\"cats-effect\"")
+    assertRoundTripParsePrint("\"cats:effect\"")
+    assertRoundTripParsePrint("title:(cats\\-effect OR cats\\:effect)")
+  }
+}

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -251,5 +251,7 @@ class QueryPrinterEscapedTermSuite extends munit.FunSuite {
     assertRoundTripParsePrint("\"cats-effect\"")
     assertRoundTripParsePrint("\"cats:effect\"")
     assertRoundTripParsePrint("title:(cats\\-effect OR cats\\:effect)")
+    assertRoundTripParsePrint("\"the cat said \\\"meow\\\" loudly\"")
+    assertRoundTripParsePrint("\"This is a blackslash: \\\\, wow!\"")
   }
 }

--- a/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/StandardQueryParserDocsSuite.scala
@@ -219,7 +219,7 @@ class StandardQueryParserDocsSuite extends munit.FunSuite {
     )
   }
 
-  test("""\:\(quoted\+term\)\:""".fail) {
+  test("""\:\(quoted\+term\)\:""") {
     val r = parseQ("""\:\(quoted\+term\)\:""")
     assert(r.isRight)
   }


### PR DESCRIPTION
This PR adds support for parsing and printing escaped string queries.

Resolves #166 

Example - queries with escaped chars will be parsed correctly:

`"cat\\:dog"` -> `Term("cat:dog")`

and when printed back out

`Term("cat:dog")` -> `"cat\\:dog"`

note: double `\\` required for scala escape