### PR TITLE
Refactor `Or` / `And` queries to always have at least two nodes.

### DIFF
--- a/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/QueryPrinterBenchmark.scala
@@ -20,8 +20,6 @@ package benchmarks
 import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 
-import cats.data.NonEmptyList
-
 /** To run the benchmark from within sbt:
   *
   * jmh:run -i 10 -wi 10 -f 2 -t 1 pink.cozydev.lucille.benchmarks.QueryPrinterBenchmark
@@ -41,8 +39,8 @@ class QueryPrinterBenchmark {
 
   @Setup
   def setup(): Unit = {
-    orQueries10 = Or(NonEmptyList(Term("o"), (1 to 10).map(i => Term(i.toString)).toList))
-    orQueries1000 = Or(NonEmptyList(Term("o"), (1 to 1000).map(i => Term(i.toString)).toList))
+    orQueries10 = Or(Term("o"), Term("o"), (1 to 10).map(i => Term(i.toString)).toList)
+    orQueries1000 = Or(Term("o"), Term("o"), (1 to 1000).map(i => Term(i.toString)).toList)
     queries = Vector(
       Term("term"),
       Phrase("phrase query"),

--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -117,13 +117,13 @@ object Query {
     *
     * @param qs the queries to union
     */
-  final case class Or(qs: NonEmptyList[Query]) extends Query {
+  final case class Or private (qs: NonEmptyList[Query]) extends Query {
     def mapLastTerm(f: Query.Term => Query): Or =
       Or(rewriteLastTerm(qs, f))
   }
   object Or {
-    def apply(head: Query, tail: Query*): Or =
-      Or(NonEmptyList(head, tail.toList))
+    def apply(left: Query, right: Query, tail: Query*): Or =
+      Or(NonEmptyList(left, right :: tail.toList))
   }
 
   /**  An And operator
@@ -132,13 +132,13 @@ object Query {
     *
     * @param qs the queries to intersect
     */
-  final case class And(qs: NonEmptyList[Query]) extends Query {
+  final case class And private (qs: NonEmptyList[Query]) extends Query {
     def mapLastTerm(f: Query.Term => Query): And =
       And(rewriteLastTerm(qs, f))
   }
   object And {
-    def apply(head: Query, tail: Query*): And =
-      And(NonEmptyList(head, tail.toList))
+    def apply(left: Query, right: Query, tail: Query*): And =
+      And(NonEmptyList(left, right :: tail.toList))
   }
 
   /** A Not operator

--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -124,6 +124,18 @@ object Query {
   object Or {
     def apply(left: Query, right: Query, tail: Query*): Or =
       Or(NonEmptyList(left, right :: tail.toList))
+
+    def apply(left: Query, right: Query, tail: List[Query]): Or =
+      Or(NonEmptyList(left, right :: tail))
+
+    def fromListUnsafe(queries: List[Query]): Or =
+      queries match {
+        case Nil =>
+          throw new IllegalArgumentException("Cannot create Or query from empty list")
+        case _ :: Nil =>
+          throw new IllegalArgumentException("Cannot create Or query from single element list")
+        case h :: t => Or(NonEmptyList(h, t))
+      }
   }
 
   /**  An And operator
@@ -139,6 +151,18 @@ object Query {
   object And {
     def apply(left: Query, right: Query, tail: Query*): And =
       And(NonEmptyList(left, right :: tail.toList))
+
+    def apply(left: Query, right: Query, tail: List[Query]): And =
+      And(NonEmptyList(left, right :: tail))
+
+    def fromListUnsafe(queries: List[Query]): And =
+      queries match {
+        case Nil =>
+          throw new IllegalArgumentException("Cannot create And query from empty list")
+        case _ :: Nil =>
+          throw new IllegalArgumentException("Cannot create And query from single element list")
+        case h :: t => And(NonEmptyList(h, t))
+      }
   }
 
   /** A Not operator

--- a/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryParser.scala
@@ -124,9 +124,9 @@ class QueryParser(
     */
   private def wrappedQueries(query: P[Query]): P[Query] =
     nelQueries(query).map {
-      case NonEmptyList(singleQ, Nil) => singleQ
-      case multipleQs =>
-        if (defaultBooleanOR) Or.apply(multipleQs) else And.apply(multipleQs)
+      case NonEmptyList(left, Nil) => left
+      case NonEmptyList(left, right :: tail) =>
+        if (defaultBooleanOR) Or(left, right, tail) else And(left, right, tail)
     }
 
   /** Recursively parse compound queries

--- a/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/QueryPrinter.scala
@@ -17,9 +17,8 @@
 package pink.cozydev.lucille
 
 import pink.cozydev.lucille.Query._
+import pink.cozydev.lucille.QueryParserHelpers._
 import cats.data.NonEmptyList
-import pink.cozydev.lucille.Parser.luceneSpecial
-import pink.cozydev.lucille.Parser.escapedTokensPhraseSet
 
 object QueryPrinter {
 

--- a/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
@@ -38,42 +38,45 @@ private[lucille] object Op {
         var currentOp = headOp
         var currentQ = headQ
 
-        // We'll collect queries in 'tempAccumulator' while successive OPs are the same type
+        // We'll collect queries in 'tempAccumulator' while successive operators are the same type
+        // e.g. (OR, q1), (OR, q2), (OR, q3), ...
         val tempAccumulator = ListBuffer.empty[Query]
         tempAccumulator += first
 
-        // When successive OPs change type, we clear 'tempAccumulator' and add them to 'outerBlder'
-        val outerBlder = ListBuffer.empty[Query]
+        // When successive operators change type, we clear 'tempAccumulator' and add them to 'bldr'
+        // e.g. (OR, q1), (AND, q2), ...
+        val bldr = ListBuffer.empty[Query]
 
-        // Iterate through OP-Query pairs, looking "one ahead" to deside how to process 'currentQ'
+        // Iterate through Op-Query pairs, looking "one ahead" to decide how to process 'currentQ'
         remaining.foreach { case (nextOp, nextQ) =>
           if (currentOp == nextOp) {
-            // nextOp hasn't changed, keep accumulating
+            // 'nextOp' hasn't changed, keep accumulating
             tempAccumulator += currentQ
           } else {
             // 'nextOp' is different from 'currentOp', so we're going to collapse the queries we've
             // accumulated so far into an AND/OR query before continuing.
-            // How we do that depends on the precedence of the operator we're switching to
-            // if we are switching to AND, it has higher precedence than OR, so we collapse before
-            // accumulating 'currentQ' and instead add it to the newly cleared accumulator.
+            // How we do that depends on the precedence of the operator we're switching to.
+            // AND has higher precedence than OR, so if we are switching from OR to AND, we
+            // collapse before accumulating 'currentQ' and instead add it to the newly cleared
+            // accumulator.
             nextOp match {
               case AND =>
                 // OR -> AND
-                // previousQ OR (currentQ AND nextQ)
+                // e.g. previousQ OR (currentQ AND nextQ)
                 // From OR to AND, collapse now, new AND gets currentQ
                 val qs = tempAccumulator.result()
                 tempAccumulator.clear()
-                outerBlder ++= qs
+                bldr ++= qs
                 tempAccumulator += currentQ
               case OR =>
                 // AND -> OR
-                // (previousQ AND currentQ) OR nextQ
+                // e.g. (previousQ AND currentQ) OR nextQ
                 // From AND to OR, add currentQ before collapsing
                 tempAccumulator += currentQ
                 val qs = tempAccumulator.result()
                 tempAccumulator.clear()
 
-                outerBlder += Query.And.fromListUnsafe(qs)
+                bldr += Query.And.fromListUnsafe(qs)
             }
           }
           // get ready for next iteration
@@ -82,22 +85,25 @@ private[lucille] object Op {
         }
 
         // We're done iterating
-        // But because we were looking one ahead, we still have not processed the last 'currentQ'
-        // Safe to add 'currentQ' to 'tempAccumulator', it's either collecting the same type of
-        // queries, or we've just emptied it for this new type of query.
+        // But because we were looking one ahead, we still have not processed the last 'currentQ'.
+        // It's safe to add 'currentQ' to 'tempAccumulator', it's either already collecting queries
+        // for 'currentOp', or we've just cleared it for a new Op type.
         tempAccumulator += currentQ
         val innerQs = tempAccumulator.result()
         currentOp match {
           case AND =>
-            // Final OP was an AND, collapse into one AND query, add to outer
-            outerBlder += Query.And.fromListUnsafe(innerQs)
+            // Final OP was an AND, collapse into one AND query, add to 'bldr'
+            bldr += Query.And.fromListUnsafe(innerQs)
           case OR =>
-            // Final OP was an OR, directly add to outer
-            outerBlder ++= innerQs
+            // Final OP was an OR, directly add to 'bldr'.
+            // Safe because all the ANDs have been grouped together.
+            // Wrapping in an OR query would create unnecessary nesting.
+            bldr ++= innerQs
         }
-        val outerQs = outerBlder.result()
-        // If we only have one query, directly return that, otherwise wrap in OR
-        if (outerQs.size == 1) outerQs.head else Query.Or.fromListUnsafe(outerQs)
+        val finalQs = bldr.result()
+        // If we only have one query, it must be an AND query, directly return that.
+        // Otherwise we wrap our multiple queries in an OR query.
+        if (finalQs.size == 1) finalQs.head else Query.Or.fromListUnsafe(finalQs)
     }
 
 }

--- a/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
@@ -17,8 +17,6 @@
 package pink.cozydev.lucille.internal
 
 import pink.cozydev.lucille.Query
-import cats.parse.Accumulator
-import cats.parse.Appender
 import scala.collection.mutable.ListBuffer
 
 private[lucille] sealed trait Op extends Product with Serializable
@@ -26,22 +24,6 @@ private[lucille] sealed trait Op extends Product with Serializable
 private[lucille] object Op {
   case object OR extends Op
   case object AND extends Op
-
-  implicit def allButLastAccumulator0[A]: Accumulator[A, (List[A], A)] =
-    new Accumulator[A, (List[A], A)] {
-      def newAppender(first: A): Appender[A, (List[A], A)] =
-        new Appender[A, (List[A], A)] {
-          var last = first
-          val bldr = List.newBuilder[A]
-          def append(item: A) = {
-            bldr += last
-            last = item
-            this
-          }
-
-          def finish() = (bldr.result(), last)
-        }
-    }
 
   /** Associates a starting query and a list of OP-Query pairs.
     *

--- a/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/internal/Op.scala
@@ -16,7 +16,6 @@
 
 package pink.cozydev.lucille.internal
 
-import cats.data.NonEmptyList
 import pink.cozydev.lucille.Query
 import cats.parse.Accumulator
 import cats.parse.Appender
@@ -91,7 +90,8 @@ private[lucille] object Op {
                 tempAccumulator += currentQ
                 val qs = tempAccumulator.result()
                 tempAccumulator.clear()
-                outerBlder += Query.And(NonEmptyList.fromListUnsafe(qs))
+
+                outerBlder += Query.And.fromListUnsafe(qs)
             }
           }
           // get ready for next iteration
@@ -108,14 +108,14 @@ private[lucille] object Op {
         currentOp match {
           case AND =>
             // Final OP was an AND, collapse into one AND query, add to outer
-            outerBlder += Query.And(NonEmptyList.fromListUnsafe(innerQs))
+            outerBlder += Query.And.fromListUnsafe(innerQs)
           case OR =>
             // Final OP was an OR, directly add to outer
             outerBlder ++= innerQs
         }
         val outerQs = outerBlder.result()
         // If we only have one query, directly return that, otherwise wrap in OR
-        if (outerQs.size == 1) outerQs.head else Query.Or(NonEmptyList.fromListUnsafe(outerQs))
+        if (outerQs.size == 1) outerQs.head else Query.Or.fromListUnsafe(outerQs)
     }
 
 }

--- a/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pink.cozydev.lucille
 
 import Query._

--- a/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
@@ -35,7 +35,7 @@ class AssociativitySuite extends munit.FunSuite {
   }
 
   val checkWithDefaultOr: (TestOptions, Query) => Unit =
-    check(QueryParser.default, "default OR :")
+    check(QueryParser.default, "default OR :") // space before colon is load bearing
 
   val checkWithDefaultAnd: (TestOptions, Query) => Unit =
     check(QueryParser.withDefaultOperatorAND, "default AND:")

--- a/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
@@ -36,8 +36,54 @@ class AssociativitySuite extends munit.FunSuite {
 
   val checkWithDefaultOr: (TestOptions, Query) => Unit =
     check(QueryParser.default, "default OR :")
+
   val checkWithDefaultAnd: (TestOptions, Query) => Unit =
     check(QueryParser.withDefaultOperatorAND, "default And:")
+
+  checkWithDefaultOr(
+    "NOT a AND b",
+    And(Not(Term("a")), Term("b")),
+  )
+  checkWithDefaultAnd(
+    "NOT a AND b",
+    And(Not(Term("a")), Term("b")),
+  )
+
+  checkWithDefaultOr(
+    "a AND NOT b",
+    And(Term("a"), Not(Term("b"))),
+  )
+  checkWithDefaultAnd(
+    "a AND NOT b",
+    And(Term("a"), Not(Term("b"))),
+  )
+
+  checkWithDefaultOr(
+    "a AND b OR x",
+    Or(And(Term("a"), Term("b")), Term("x")),
+  )
+  checkWithDefaultAnd(
+    "a AND b OR x",
+    Or(And(Term("a"), Term("b")), Term("x")),
+  )
+
+  checkWithDefaultOr(
+    "a AND b OR x AND y",
+    Or(And(Term("a"), Term("b")), And(Term("x"), Term("y"))),
+  )
+  checkWithDefaultAnd(
+    "a AND b OR x AND y",
+    Or(And(Term("a"), Term("b")), And(Term("x"), Term("y"))),
+  )
+
+  checkWithDefaultOr(
+    "a AND b AND c OR x",
+    Or(And(Term("a"), Term("b"), Term("c")), Term("x")),
+  )
+  checkWithDefaultAnd(
+    "a AND b AND c OR x",
+    Or(And(Term("a"), Term("b"), Term("c")), Term("x")),
+  )
 
   checkWithDefaultOr(
     "a b AND c",

--- a/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
@@ -1,0 +1,96 @@
+package pink.cozydev.lucille
+
+import Query._
+import munit.TestOptions
+
+class AssociativitySuite extends munit.FunSuite {
+
+  // Using `TestOptions` like this let's us still use `.only` on the test input/name
+  def check(parser: QueryParser, prefix: String)(
+      options: TestOptions,
+      expected: Query,
+  )(implicit loc: munit.Location): Unit = {
+    val queryString = options.name
+    val testName = s"$prefix '$queryString'"
+    test(options.withName(testName)) {
+      val actual = parser.parse(queryString)
+      assertEquals(actual, Right(expected))
+    }
+  }
+
+  val checkWithDefaultOr = check(QueryParser.default, "default OR :")
+  val checkWithDefaultAnd = check(QueryParser.withDefaultOperatorAND, "default And:")
+
+  checkWithDefaultOr(
+    "a b AND c",
+    Or(Term("a"), And(Term("b"), Term("c"))),
+  )
+  checkWithDefaultAnd(
+    "a b AND c",
+    And(Term("a"), And(Term("b"), Term("c"))),
+  )
+
+  checkWithDefaultOr(
+    "a b AND c d",
+    Or(Term("a"), And(Term("b"), Term("c")), Term("d")),
+  )
+  checkWithDefaultAnd(
+    "a b AND c d",
+    And(Term("a"), And(Term("b"), Term("c")), Term("d")),
+  )
+
+  checkWithDefaultOr(
+    "a b AND c AND d",
+    Or(Term("a"), And(Term("b"), Term("c"), Term("d"))),
+  )
+  checkWithDefaultAnd(
+    "a b AND c AND d",
+    And(Term("a"), And(Term("b"), Term("c"), Term("d"))),
+  )
+
+  checkWithDefaultOr(
+    "a b AND c AND d AND e",
+    Or(Term("a"), And(Term("b"), Term("c"), Term("d"), Term("e"))),
+  )
+  checkWithDefaultAnd(
+    "a b AND c AND d AND e",
+    And(Term("a"), And(Term("b"), Term("c"), Term("d"), Term("e"))),
+  )
+
+  checkWithDefaultOr(
+    "a b AND c AND d OR e",
+    Or(Term("a"), Or(And(Term("b"), Term("c"), Term("d")), Term("e"))),
+  )
+  checkWithDefaultAnd(
+    "a b AND c AND d OR e",
+    And(Term("a"), Or(And(Term("b"), Term("c"), Term("d")), Term("e"))),
+  )
+
+  checkWithDefaultOr(
+    "a b AND c OR d e",
+    Or(Term("a"), Or(And(Term("b"), Term("c")), Term("d")), Term("e")),
+  )
+  checkWithDefaultAnd(
+    "a b AND c OR d e",
+    And(Term("a"), Or(And(Term("b"), Term("c")), Term("d")), Term("e")),
+  )
+
+  checkWithDefaultOr(
+    "a b AND c OR d AND e",
+    Or(Term("a"), Or(And(Term("b"), Term("c")), And(Term("d"), Term("e")))),
+  )
+  checkWithDefaultAnd(
+    "a b AND c OR d AND e",
+    And(Term("a"), Or(And(Term("b"), Term("c")), And(Term("d"), Term("e")))),
+  )
+
+  checkWithDefaultOr(
+    "a b AND c OR d OR e",
+    Or(Term("a"), Or(And(Term("b"), Term("c")), Term("d"), Term("e"))),
+  )
+  checkWithDefaultAnd(
+    "a b AND c OR d OR e",
+    And(Term("a"), Or(And(Term("b"), Term("c")), Term("d"), Term("e"))),
+  )
+
+}

--- a/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
@@ -38,7 +38,7 @@ class AssociativitySuite extends munit.FunSuite {
     check(QueryParser.default, "default OR :")
 
   val checkWithDefaultAnd: (TestOptions, Query) => Unit =
-    check(QueryParser.withDefaultOperatorAND, "default And:")
+    check(QueryParser.withDefaultOperatorAND, "default AND:")
 
   checkWithDefaultOr(
     "NOT a AND b",

--- a/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/AssociativitySuite.scala
@@ -34,8 +34,10 @@ class AssociativitySuite extends munit.FunSuite {
     }
   }
 
-  val checkWithDefaultOr = check(QueryParser.default, "default OR :")
-  val checkWithDefaultAnd = check(QueryParser.withDefaultOperatorAND, "default And:")
+  val checkWithDefaultOr: (TestOptions, Query) => Unit =
+    check(QueryParser.default, "default OR :")
+  val checkWithDefaultAnd: (TestOptions, Query) => Unit =
+    check(QueryParser.withDefaultOperatorAND, "default And:")
 
   checkWithDefaultOr(
     "a b AND c",

--- a/core/src/test/scala/pink/cozydev/lucille/DefaultBooleanAndSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/DefaultBooleanAndSuite.scala
@@ -53,4 +53,28 @@ class DefaultBooleanAndSuite extends munit.FunSuite {
     assertEquals(actual, Right(expected))
   }
 
+  test("DefaultBooleanAnd parse complex mix of AND and OR queries with trailing terms") {
+    val actual = parseQ("derp AND lerp slerp orA OR orB last")
+    val expected =
+      And(
+        And(Term("derp"), Term("lerp")),
+        Term("slerp"),
+        Or(Term("orA"), Term("orB")),
+        Term("last"),
+      )
+    assertEquals(actual, Right(expected))
+  }
+
+  test("DefaultBooleanAnd parse complex mix of OR and AND queries with trailing terms") {
+    val actual = parseQ("derp OR lerp slerp andA AND andB last")
+    val expected =
+      And(
+        Or(Term("derp"), Term("lerp")),
+        Term("slerp"),
+        And(Term("andA"), Term("andB")),
+        Term("last"),
+      )
+    assertEquals(actual, Right(expected))
+  }
+
 }

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -354,6 +354,21 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     )
   }
 
+  test("parse complex mix of OR and AND queries with trailing terms") {
+    val r = parseQ("derp OR lerp slerp andA AND andB last")
+    assertEquals(
+      r,
+      Right(
+        Or(
+          Or(Term("derp"), Term("lerp")),
+          Term("slerp"),
+          And(Term("andA"), Term("andB")),
+          Term("last"),
+        )
+      ),
+    )
+  }
+
   test("the cat AND ocean AND ocean2 OR fish") {
     val r = parseQ("the cat AND ocean AND ocean2 OR fish")
     assertEquals(

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -354,6 +354,22 @@ class QueryWithSuffixOpsSuite extends munit.FunSuite {
     )
   }
 
+  test("the cat AND ocean AND ocean2 OR fish") {
+    val r = parseQ("the cat AND ocean AND ocean2 OR fish")
+    assertEquals(
+      r,
+      Right(
+        Or(
+          Term("the"),
+          Or(
+            And(Term("cat"), Term("ocean"), Term("ocean2")),
+            Term("fish"),
+          ),
+        )
+      ),
+    )
+  }
+
   test("parse NOT query") {
     val r = parseQ("NOT derp")
     assertEquals(
@@ -389,7 +405,7 @@ class GroupQuerySuite extends munit.FunSuite {
     )
   }
 
-  test("parse multiple terms with trailing spaces in a group".fail) {
+  test("parse multiple terms with trailing spaces in a group") {
     val r = parseQ("(The cat   jumped   )")
     assertEquals(
       r,

--- a/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/ParserSuite.scala
@@ -15,7 +15,6 @@
  */
 
 package pink.cozydev.lucille
-import cats.data.NonEmptyList
 import Query._
 
 class SingleSimpleQuerySuite extends munit.FunSuite {
@@ -475,40 +474,13 @@ class GroupQuerySuite extends munit.FunSuite {
 
   test("parse nested group query with trailing term") {
     val r = parseQ("(title:test AND (pass OR fail)) extra")
-    val gq = And(
-      NonEmptyList.of(
-        Field("title", Term("test")),
-        Group(
-          Or(Term("pass"), Term("fail"))
-        ),
-      )
-    )
-    assertEquals(
-      r,
-      Right(
-        Or(Group(gq), Term("extra"))
-      ),
-    )
+    val gq = And(Field("title", Term("test")), Group(Or(Term("pass"), Term("fail"))))
+    assertEquals(r, Right(Or(Group(gq), Term("extra"))))
   }
 
   test("parse nested group query AND'd with a phrase query") {
     val r = parseQ("(title:test AND (pass OR fail)) AND \"extra phrase\"")
-    val gq = And(
-      NonEmptyList.of(
-        Field("title", Term("test")),
-        Group(
-          Or(Term("pass"), Term("fail"))
-        ),
-      )
-    )
-    assertEquals(
-      r,
-      Right(
-        And(
-          Group(gq),
-          Phrase("extra phrase"),
-        )
-      ),
-    )
+    val gq = And(Field("title", Term("test")), Group(Or(Term("pass"), Term("fail"))))
+    assertEquals(r, Right(And(Group(gq), Phrase("extra phrase"))))
   }
 }

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -22,13 +22,13 @@ import cats.data.NonEmptyList
 class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
 
   test("prints OR query") {
-    val q = Or(NonEmptyList.of(Term("hello"), Term("hi")))
+    val q = Or(Term("hello"), Term("hi"))
     val str = QueryPrinter.print(q)
     assertEquals(str, "hello OR hi")
   }
 
   test("prints AND query") {
-    val q = And(NonEmptyList.of(Term("hello"), Term("hi")))
+    val q = And(Term("hello"), Term("hi"))
     val str = QueryPrinter.print(q)
     assertEquals(str, "hello AND hi")
   }
@@ -76,7 +76,7 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
   }
 
   test("prints Boost query") {
-    val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 2.25f)
+    val q = Boost(Or(Term("hello"), Term("hi")), 2.25f)
     val str = QueryPrinter.print(q)
     assertEquals(str, "(hello OR hi)^2.25")
   }
@@ -88,13 +88,13 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
   }
 
   test("prints Boost query with precision zero") {
-    val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 3.1f)
+    val q = Boost(Or(Term("hello"), Term("hi")), 3.1f)
     val str = QueryPrinter.print(q, 0)
     assertEquals(str, "(hello OR hi)^3")
   }
 
   test("prints Boost query with precision") {
-    val q = Boost(Or(NonEmptyList.of(Term("hello"), Term("hi"))), 3.1f)
+    val q = Boost(Or(Term("hello"), Term("hi")), 3.1f)
     val str = QueryPrinter.print(q, 1)
     assertEquals(str, "(hello OR hi)^3.1")
   }

--- a/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QueryPrinterSuite.scala
@@ -108,7 +108,7 @@ class QueryPrinterSimpleQueriesSuite extends munit.FunSuite {
   test("prints Boost query with other queries included") {
     val q = Or(
       Boost(
-        Or(Field("fieldA", Group(Or(Or(Term("a"), Term("b")), Not(Term("c")))))),
+        Field("fieldA", Group(Or(Or(Term("a"), Term("b")), Not(Term("c"))))),
         2.50f,
       ),
       Field("fieldB", Term("d")),

--- a/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/QuerySuite.scala
@@ -17,7 +17,6 @@
 package pink.cozydev.lucille
 
 import pink.cozydev.lucille.Query._
-import cats.data.NonEmptyList
 
 class QuerySuite extends munit.FunSuite {
 
@@ -73,15 +72,15 @@ class QuerySuite extends munit.FunSuite {
 
   test("Query.and performs logical AND with Query and argument") {
     val q1 = Term("cats")
-    val q2 = Or(NonEmptyList.of(Term("dogs"), Term("fish")))
-    val expected = And(NonEmptyList.of(q1, q2))
+    val q2 = Or(Term("dogs"), Term("fish"))
+    val expected = And(q1, q2)
     assertEquals(q1.and(q2), expected)
   }
 
   test("Query.or performs logical OR with Query and argument") {
     val q1 = Term("dogs")
     val q2 = Term("cats")
-    val expected = Or(NonEmptyList.of(q1, q2))
+    val expected = Or(q1, q2)
     assertEquals(q1.or(q2), expected)
   }
 

--- a/core/src/test/scala/pink/cozydev/lucille/internal/OpSuite.scala
+++ b/core/src/test/scala/pink/cozydev/lucille/internal/OpSuite.scala
@@ -15,7 +15,6 @@
  */
 
 package pink.cozydev.lucille.internal
-import cats.data.NonEmptyList
 import pink.cozydev.lucille.Query._
 import Op._
 
@@ -77,7 +76,7 @@ class AssociateOpsSuite extends munit.FunSuite {
     val double = opQs ++ opQs
     val result = associateOps(Term("cat"), double)
     val oceanQs = List(Term("ocean"), And(Term("coast"), Term("island")), Term("ocean"))
-    val expected = Or(NonEmptyList(Term("cat"), oceanQs ++ oceanQs))
+    val expected = Or(Term("cat"), oceanQs.head, oceanQs.tail ++ oceanQs)
     assertEquals(result, expected)
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,3 +94,23 @@ This also works when the last term is part of a boolean or field query.
 ```scala mdoc
 QueryParser.parse("cats AND do").map(mq => mq.mapLastTerm(expandQ))
 ```
+
+### Associativity
+
+Queries may contain a mix of AND/OR operators, e.g. `cats AND dogs OR fish`.
+It is best to add parenthesis to help indicate your intent, either `(cats AND dogs) OR fish` or `cats AND (dogs OR fish)`, as both of these queries could evaluate differently.
+In the absence of clarifying parenthesis, Lucille parses according to the precedence of the boolean operators.
+The highest and most immediately binding operator is `NOT`, then `AND` and finally `OR`.
+
+Consider the following examples:
+
+```
+NOT a AND b         ->  (NOT A) AND b
+a AND NOT b         ->  A AND (NOT b)
+a AND b OR x        ->  (a AND b) OR x
+a AND b OR x AND y  ->  (a AND b) OR (x AND y)
+a AND b AND c OR x  ->  (a AND b AND c) OR x
+```
+
+It's worth noting that the last example could equivalently be written as `((a AND b) AND c) OR x` or `(a AND (b AND c)) OR x`.
+However, Lucille parses sequences of repeated operators into a single `Query.And` or `Query.Or` node to avoid unnecessary nesting.


### PR DESCRIPTION
This PR makes it "impossible"[^1] to have a `Query.And` or `Query.Or` with only one sub query.

```scala
Query.And(NonEmptyList.of(Query.Term("a")))  // not possible
```
Similarly with `Query.Or`

Thereby resolving the remaining part of https://github.com/cozydev-pink/lucille/issues/142, problem 1.


[^1]: I say "impossible" because you could still create a `Query.And` with two queries, and then modify the `NonEmptyList` to only have one. Actually making it impossible would require a model change like in https://github.com/cozydev-pink/lucille/pull/172, and I'm not sure which way to go regarding that yet.