### PR TITLE
Add parser and mapLastTerm benchmarks

### DIFF
--- a/benchmarks/src/main/scala/pink/cozydev/lucille/MapLastTermBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/MapLastTermBenchmark.scala
@@ -36,8 +36,7 @@ class MapLastTermBenchmark {
 
   val fullQuery: String =
     "this is a long query that will be broken up into one query per character in this string"
-  var partialQueries: Vector[String] = _
-  val associativityQueries = Vector(
+  val associativityQueryStrings = Vector(
     "NOT a AND b",
     "a AND NOT b",
     "a AND b OR x",
@@ -53,16 +52,24 @@ class MapLastTermBenchmark {
     "a b AND c OR d OR e",
   )
 
+  var partialQueries: Vector[Query] = _
+  var associativityQueries: Vector[Query] = _
+
   @Setup
   def setup(): Unit =
-    partialQueries = (1 to fullQuery.size).map(fullQuery.take).toVector
+    partialQueries = (1 to fullQuery.size)
+      .map(fullQuery.take)
+      .toVector
+      .map(QueryParser.default.parse)
+      .map(_.toOption.get)
+  associativityQueries = associativityQueryStrings.map(QueryParser.parse).map(_.toOption.get)
 
   @Benchmark
   def partialQueriesMapLastTerm(): Unit =
-    partialQueries.foreach(q => QueryParser.default.parse(q).map(_.mapLastTerm(rewriteQ)))
+    partialQueries.foreach(q => q.mapLastTerm(rewriteQ))
 
   @Benchmark
   def associativityQueriesMapLastTerm(): Unit =
-    associativityQueries.foreach(q => QueryParser.default.parse(q).map(_.mapLastTerm(rewriteQ)))
+    associativityQueries.foreach(q => q.mapLastTerm(rewriteQ))
 
 }

--- a/benchmarks/src/main/scala/pink/cozydev/lucille/MapLastTermBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/MapLastTermBenchmark.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.lucille
+package benchmarks
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+/** To run the benchmark from within sbt:
+  *
+  * jmh:run -i 10 -wi 10 -f 2 -t 1 pink.cozydev.lucille.benchmarks.MapLastTermBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread". Please note that
+  * benchmarks should be usually executed at least in 10 iterations (as a rule of thumb), but
+  * more is better.
+  */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+class MapLastTermBenchmark {
+
+  val rewriteQ = (t: Query.Term) => Query.Or(t, Query.Prefix(t.str))
+
+  val fullQuery: String =
+    "this is a long query that will be broken up into one query per character in this string"
+  var partialQueries: Vector[String] = _
+  val associativityQueries = Vector(
+    "NOT a AND b",
+    "a AND NOT b",
+    "a AND b OR x",
+    "a AND b OR x AND y",
+    "a AND b AND c OR x",
+    "a b AND c",
+    "a b AND c d",
+    "a b AND c AND d",
+    "a b AND c AND d AND e",
+    "a b AND c AND d OR e",
+    "a b AND c OR d e",
+    "a b AND c OR d AND e",
+    "a b AND c OR d OR e",
+  )
+
+  @Setup
+  def setup(): Unit =
+    partialQueries = (1 to fullQuery.size).map(fullQuery.take).toVector
+
+  @Benchmark
+  def partialQueriesMapLastTerm(): Unit =
+    partialQueries.foreach(q => QueryParser.default.parse(q).map(_.mapLastTerm(rewriteQ)))
+
+  @Benchmark
+  def associativityQueriesMapLastTerm(): Unit =
+    associativityQueries.foreach(q => QueryParser.default.parse(q).map(_.mapLastTerm(rewriteQ)))
+
+}

--- a/benchmarks/src/main/scala/pink/cozydev/lucille/QueryParserBenchmark.scala
+++ b/benchmarks/src/main/scala/pink/cozydev/lucille/QueryParserBenchmark.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 CozyDev
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pink.cozydev.lucille
+package benchmarks
+
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+
+/** To run the benchmark from within sbt:
+  *
+  * jmh:run -i 10 -wi 10 -f 2 -t 1 pink.cozydev.lucille.benchmarks.QueryParserBenchmark
+  *
+  * Which means "10 iterations", "10 warm-up iterations", "2 forks", "1 thread". Please note that
+  * benchmarks should be usually executed at least in 10 iterations (as a rule of thumb), but
+  * more is better.
+  */
+@State(Scope.Benchmark)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+class QueryParserBenchmark {
+
+  val orQueries10: String = "o 1 2 3 4 5 6 7 8 9"
+  var orQueries1000: String = _
+  val associativityQueries = Vector(
+    "NOT a AND b",
+    "a AND NOT b",
+    "a AND b OR x",
+    "a AND b OR x AND y",
+    "a AND b AND c OR x",
+    "a b AND c",
+    "a b AND c d",
+    "a b AND c AND d",
+    "a b AND c AND d AND e",
+    "a b AND c AND d OR e",
+    "a b AND c OR d e",
+    "a b AND c OR d AND e",
+    "a b AND c OR d OR e",
+  )
+
+  @Setup
+  def setup(): Unit =
+    orQueries1000 = (1 to 1000).mkString("o ", " ", "")
+
+  @Benchmark
+  def orQueries10Parse(): Either[String, Query] =
+    QueryParser.default.parse(orQueries10)
+
+  @Benchmark
+  def orQueries1000Parse(): Either[String, Query] =
+    QueryParser.default.parse(orQueries1000)
+
+  @Benchmark
+  def associativityQueriesParse(): Unit =
+    associativityQueries.foreach(QueryParser.default.parse)
+
+}


### PR DESCRIPTION
This PR adds two new benchmarking suites.

QueryParserBenchmark tests the parser on implicit OR queries and some simple associativity testing queries from https://github.com/cozydev-pink/lucille/pull/170.

MapLastTermBenchmark test the `mapLastTerm` method on the same associativity queries and a incrementally built up "long" query.
The `mapLastTerm` benchmark is meant to try and capture a bit of how Lucille might be used in an interactive search environment.
[Protosearch currently uses ](https://github.com/cozydev-pink/protosearch/blob/82ae0c3e494a22280eee2155d8efbd2be31c5cfa/core/src/main/scala/pink/cozydev/protosearch/MultiIndex.scala#L59-L64)`mapLastTerm` on basically every key press in the search bar, so it's important that it's quick.

I am mostly adding these to make sure that https://github.com/cozydev-pink/lucille/pull/170 isn't a big regression or anything.