### PR TITLE
Seal boolean Query, protecting two query invariant

### DIFF
--- a/core/src/main/scala/pink/cozydev/lucille/Query.scala
+++ b/core/src/main/scala/pink/cozydev/lucille/Query.scala
@@ -117,16 +117,16 @@ object Query {
     *
     * @param qs the queries to union
     */
-  final case class Or private (qs: NonEmptyList[Query]) extends Query {
+  sealed abstract case class Or private (qs: NonEmptyList[Query]) extends Query {
     def mapLastTerm(f: Query.Term => Query): Or =
-      Or(rewriteLastTerm(qs, f))
+      new Or(rewriteLastTerm(qs, f)) {}
   }
   object Or {
     def apply(left: Query, right: Query, tail: Query*): Or =
-      Or(NonEmptyList(left, right :: tail.toList))
+      new Or(NonEmptyList(left, right :: tail.toList)) {}
 
     def apply(left: Query, right: Query, tail: List[Query]): Or =
-      Or(NonEmptyList(left, right :: tail))
+      new Or(NonEmptyList(left, right :: tail)) {}
 
     def fromListUnsafe(queries: List[Query]): Or =
       queries match {
@@ -134,7 +134,7 @@ object Query {
           throw new IllegalArgumentException("Cannot create Or query from empty list")
         case _ :: Nil =>
           throw new IllegalArgumentException("Cannot create Or query from single element list")
-        case h :: t => Or(NonEmptyList(h, t))
+        case h :: t => new Or(NonEmptyList(h, t)) {}
       }
   }
 
@@ -144,16 +144,16 @@ object Query {
     *
     * @param qs the queries to intersect
     */
-  final case class And private (qs: NonEmptyList[Query]) extends Query {
+  sealed abstract case class And private (qs: NonEmptyList[Query]) extends Query {
     def mapLastTerm(f: Query.Term => Query): And =
-      And(rewriteLastTerm(qs, f))
+      new And(rewriteLastTerm(qs, f)) {}
   }
   object And {
     def apply(left: Query, right: Query, tail: Query*): And =
-      And(NonEmptyList(left, right :: tail.toList))
+      new And(NonEmptyList(left, right :: tail.toList)) {}
 
     def apply(left: Query, right: Query, tail: List[Query]): And =
-      And(NonEmptyList(left, right :: tail))
+      new And(NonEmptyList(left, right :: tail)) {}
 
     def fromListUnsafe(queries: List[Query]): And =
       queries match {
@@ -161,7 +161,7 @@ object Query {
           throw new IllegalArgumentException("Cannot create And query from empty list")
         case _ :: Nil =>
           throw new IllegalArgumentException("Cannot create And query from single element list")
-        case h :: t => And(NonEmptyList(h, t))
+        case h :: t => new And(NonEmptyList(h, t)) {}
       }
   }
 


### PR DESCRIPTION
![sealed-abstract-case-class](https://github.com/user-attachments/assets/107e7d3c-e25a-4453-bb9e-5d142fa35994)


Prior to this one could create a two-query `Query.And` and then be evil and modify it!

```scala
scala> val q = Query.And(Query.Term("a"), Query.Term("b"))
q: pink.cozydev.lucille.Query.And = And(NonEmptyList(Term(a), Term(b)))

scala> q.copy(qs = NonEmptyList.one(Query.Term("a")))
res1: pink.cozydev.lucille.Query.And = And(NonEmptyList(Term(a)))   // the horror!
```

Now you can't, there's no public `copy` method anymore.

Closes https://github.com/cozydev-pink/lucille/issues/142